### PR TITLE
Node registry + capability-advertisement consumer

### DIFF
--- a/data_ingestion_layer/framework/node_registry.py
+++ b/data_ingestion_layer/framework/node_registry.py
@@ -1,0 +1,62 @@
+"""Node registry: persists each edge node's advertised capabilities and the assignment the
+server negotiated for it, and resolves a capability advertisement into (capabilities,
+assignment) for the registry + the config reply.
+
+Storage is the global (non mode-isolated) `iotsensing.nodes` collection, keyed by node_id.
+The pure resolution logic (process_capabilities) is separated from Mongo so it is unit-testable.
+"""
+from typing import Optional, Tuple, List
+
+from framework.node_capabilities import (
+    NodeCapabilities,
+    NodeAssignment,
+    negotiate_assignment,
+    validate_capabilities,
+)
+
+
+def process_capabilities(
+    data: dict,
+    required_features: Optional[List[str]] = None,
+) -> Tuple[Optional[NodeCapabilities], Optional[NodeAssignment], List[str]]:
+    """Validate + parse a capability advertisement and negotiate an assignment.
+
+    Returns (capabilities, assignment, problems). On a fatal problem (no node_id) returns
+    (None, None, problems); non-fatal problems (e.g. an unknown advertised feature) are
+    returned but still produce a capabilities/assignment, since negotiation already ignores
+    untrusted features.
+    """
+    problems = validate_capabilities(data)
+    if not isinstance(data, dict) or not data.get("node_id"):
+        return None, None, problems
+    caps = NodeCapabilities.from_dict(data)
+    assignment = negotiate_assignment(caps, required_features=required_features)
+    return caps, assignment, problems
+
+
+class NodeRegistry:
+    """Mongo-backed store of node capabilities + negotiated assignments (upsert by node_id)."""
+
+    def __init__(self, collection):
+        self.collection = collection
+
+    def register(
+        self,
+        caps: NodeCapabilities,
+        assignment: NodeAssignment,
+        last_seen=None,
+    ) -> dict:
+        doc = {
+            "node_id": caps.node_id,
+            "capabilities": caps.to_dict(),
+            "assignment": assignment.to_dict(),
+            "last_seen": last_seen,
+        }
+        self.collection.update_one({"node_id": caps.node_id}, {"$set": doc}, upsert=True)
+        return doc
+
+    def get(self, node_id: str) -> Optional[dict]:
+        return self.collection.find_one({"node_id": node_id}, {"_id": 0})
+
+    def all(self) -> List[dict]:
+        return list(self.collection.find({}, {"_id": 0}))

--- a/data_ingestion_layer/node_registry_service.py
+++ b/data_ingestion_layer/node_registry_service.py
@@ -1,0 +1,81 @@
+"""Node registry service: the server side of the edge capability handshake.
+
+Subscribes to `nodes/+/capabilities` (retained advertisements from ESP32-S3 nodes),
+validates + negotiates an assignment, persists both to the `iotsensing.nodes` registry, and
+replies on `nodes/{id}/config` (retained) with what the node should compute and send.
+
+Env: MONGO_URL, MQTT_HOST, MQTT_PORT, MQTT_USER, MQTT_PASS.
+"""
+import os
+import json
+from datetime import datetime, timezone
+
+from pymongo import MongoClient
+import paho.mqtt.client as mqtt
+from paho.mqtt.client import CallbackAPIVersion
+
+from framework.mqtt_auth import apply_mqtt_auth
+from framework.node_registry import NodeRegistry, process_capabilities
+
+MONGO_URL = os.environ.get("MONGO_URL", "mongodb://mongodb:27017")
+MQTT_HOST = os.environ.get("MQTT_HOST", "mqtt")
+MQTT_PORT = int(os.environ.get("MQTT_PORT", 1883))
+
+CAPABILITIES_TOPIC = "nodes/+/capabilities"
+
+
+def node_id_from_topic(topic: str):
+    parts = topic.split("/")
+    return parts[1] if len(parts) >= 3 and parts[0] == "nodes" else None
+
+
+class NodeRegistryService:
+    def __init__(self, mongo_url=MONGO_URL, mqtt_host=MQTT_HOST, mqtt_port=MQTT_PORT):
+        self.mongo_client = MongoClient(mongo_url)
+        # Global (non mode-isolated) registry, like board/system settings.
+        self.registry = NodeRegistry(self.mongo_client["iotsensing"]["nodes"])
+
+        self.mqtt_client = mqtt.Client(callback_api_version=CallbackAPIVersion.VERSION2)
+        apply_mqtt_auth(self.mqtt_client)
+        self.mqtt_client.on_connect = self.on_connect
+        self.mqtt_client.on_message = self.on_message
+        self.mqtt_client.connect(mqtt_host, mqtt_port, 60)
+        print(f"Node Registry Service initialized (mongo={mongo_url}, mqtt={mqtt_host}:{mqtt_port})")
+
+    def on_connect(self, client, userdata, flags, rc, properties=None):
+        print(f"Connected to MQTT broker with result code {rc}")
+        client.subscribe(CAPABILITIES_TOPIC)
+        print(f"Subscribed to {CAPABILITIES_TOPIC}")
+
+    def on_message(self, client, userdata, msg):
+        try:
+            data = json.loads(msg.payload.decode())
+            # The topic addresses the node; fill node_id from it if the payload omits it.
+            topic_id = node_id_from_topic(msg.topic)
+            if topic_id and not data.get("node_id"):
+                data["node_id"] = topic_id
+
+            caps, assignment, problems = process_capabilities(data)
+            if problems:
+                print(f"Capability advert from '{data.get('node_id', topic_id)}' has issues: {problems}")
+            if caps is None:
+                print(f"Ignoring invalid capability advert on {msg.topic}")
+                return
+
+            self.registry.register(caps, assignment, last_seen=datetime.now(timezone.utc))
+            client.publish(
+                f"nodes/{caps.node_id}/config",
+                json.dumps(assignment.to_dict()),
+                retain=True,
+            )
+            print(f"Registered node '{caps.node_id}' -> assignment mode={assignment.mode} "
+                  f"features={assignment.features}")
+        except Exception as e:
+            print(f"Error handling capability advert on '{msg.topic}':", e)
+
+    def run(self):
+        self.mqtt_client.loop_forever()
+
+
+if __name__ == "__main__":
+    NodeRegistryService().run()

--- a/data_ingestion_layer/tests/test_node_registry.py
+++ b/data_ingestion_layer/tests/test_node_registry.py
@@ -1,0 +1,74 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from framework.node_registry import NodeRegistry, process_capabilities
+from framework.node_capabilities import (
+    NodeCapabilities, NodeProvides, NodeAssignment, OFFLOADABLE_FEATURES,
+    MODE_FEATURES, MODE_RAW,
+)
+from node_registry_service import node_id_from_topic
+
+
+class FakeCollection:
+    """Minimal in-memory stand-in for a Mongo collection (upsert by node_id)."""
+    def __init__(self):
+        self.docs = {}
+
+    def update_one(self, flt, update, upsert=False):
+        self.docs[flt["node_id"]] = dict(update["$set"])
+
+    def find_one(self, flt, projection=None):
+        d = self.docs.get(flt["node_id"])
+        return dict(d) if d else None
+
+    def find(self, flt, projection=None):
+        return [dict(v) for v in self.docs.values()]
+
+
+def test_process_valid_advert():
+    data = {"node_id": "n1", "provides": {"vad": True, "features": list(OFFLOADABLE_FEATURES)}}
+    caps, assignment, problems = process_capabilities(data)
+    assert caps.node_id == "n1"
+    assert assignment.mode == MODE_FEATURES
+    assert problems == []
+
+
+def test_process_missing_node_id_is_fatal():
+    caps, assignment, problems = process_capabilities({"provides": {}})
+    assert caps is None and assignment is None
+    assert any("node_id" in p for p in problems)
+
+
+def test_process_unknown_feature_is_nonfatal():
+    caps, assignment, problems = process_capabilities({"node_id": "n1", "provides": {"features": ["bogus"]}})
+    assert caps is not None
+    assert any("bogus" in p for p in problems)
+    assert assignment.mode == MODE_RAW  # no vad, no usable features -> raw
+
+
+def test_registry_register_get_all():
+    reg = NodeRegistry(FakeCollection())
+    caps = NodeCapabilities("n1", provides=NodeProvides(features=["snr"]))
+    reg.register(caps, NodeAssignment(mode="raw"), last_seen="t0")
+    got = reg.get("n1")
+    assert got["node_id"] == "n1"
+    assert got["capabilities"]["provides"]["features"] == ["snr"]
+    assert got["assignment"]["mode"] == "raw"
+    assert got["last_seen"] == "t0"
+    assert len(reg.all()) == 1
+
+
+def test_register_is_upsert():
+    reg = NodeRegistry(FakeCollection())
+    c = NodeCapabilities("n1")
+    reg.register(c, NodeAssignment(mode="raw"))
+    reg.register(c, NodeAssignment(mode="features"))
+    assert len(reg.all()) == 1
+    assert reg.get("n1")["assignment"]["mode"] == "features"
+
+
+def test_node_id_from_topic():
+    assert node_id_from_topic("nodes/board-7/capabilities") == "board-7"
+    assert node_id_from_topic("voice/1/b/env") is None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,6 +139,24 @@ services:
       environment:
          <<: [*mongo-env, *mqtt-env]
 
+   node_registry_service:
+      build:
+         context: ./data_ingestion_layer
+         dockerfile: Dockerfile.respeaker
+      restart: unless-stopped
+      deploy:
+         resources:
+            limits:
+               memory: 256M
+      command: python node_registry_service.py
+      volumes:
+         - ./data_ingestion_layer:/app
+      depends_on:
+         - mqtt
+         - mongodb
+      environment:
+         <<: [*mongo-env, *mqtt-env]
+
    temporal_context_modeling_layer:
       build:
          context: ./temporal_context_modeling_layer


### PR DESCRIPTION
Step 2 of edge offloading: the server side of the capability handshake (builds on the schema/gap-filler from #82).

## What it does
ESP32-S3 nodes publish a retained capability advert to `nodes/{id}/capabilities`. A new service negotiates an assignment, persists both, and replies on `nodes/{id}/config` (retained) — so a node learns what to compute and send as soon as it connects.

## Pieces
- **`framework/node_registry.py`** — `NodeRegistry` (Mongo-backed, upsert by `node_id` into `iotsensing.nodes`, stores capabilities + assignment + `last_seen`) and a pure `process_capabilities()` (validate → parse → negotiate) for testability.
- **`node_registry_service.py`** — standalone authenticated MQTT service: subscribe `nodes/+/capabilities` → negotiate → persist → publish `nodes/{id}/config` (retained).
- **compose** — new `node_registry_service` (cred env via the existing anchors).

## Validation
- 6 registry + 7 capability unit tests pass.
- **E2E on the auth stack**: a published advert (node provides all offloadable features + VAD) was stored in `iotsensing.nodes`, and the service replied on `nodes/board-test/config` with `mode=features` (no raw audio) — the full advertise → negotiate → assign loop.

## Next
- Tier-1 on-node VAD firmware (biggest bandwidth/privacy win); a dashboard view of registered nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)