### PR TITLE
Firmware sketch: plug-and-play edge-offload (ReSpeaker Lite / XVF3800)

### DIFF
--- a/data_ingestion_layer/firmware/main/CMakeLists.txt
+++ b/data_ingestion_layer/firmware/main/CMakeLists.txt
@@ -12,6 +12,13 @@ set(SRCS
     "network/wifi_manager.c"
     "network/tcp_client.c"
     "system/watchdog.c"
+    # --- Plug-and-play edge-offload (see docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md) ---
+    "app/offload_app.c"
+    "provisioning/provisioning.c"
+    "net/discovery.c"
+    "net/mqtt_client.c"
+    "protocol/node_protocol.c"
+    "features/edge_features.c"
 )
 
 # Add XVF3800 driver for that board variant
@@ -31,6 +38,11 @@ set(INCLUDE_DIRS
     "network"
     "system"
     "drivers"
+    "app"
+    "provisioning"
+    "net"
+    "protocol"
+    "features"
 )
 
 # Register component with ESP-IDF build system
@@ -47,6 +59,13 @@ idf_component_register(
         esp_timer
         esp_psram
         esp_system
+        # Plug-and-play edge-offload deps:
+        mqtt                 # esp-mqtt (broker transport)
+        mdns                 # sink discovery (_iotsensing-mqtt._tcp)
+        wifi_provisioning    # SoftAP/BLE first-boot Wi-Fi setup
+        json                 # cJSON (protocol payloads)
+        # esp-dsp is a managed component: add espressif/esp-dsp to idf_component.yml for
+        # on-node feature extraction (features/edge_features.c).
 )
 
 # Add compiler warnings

--- a/data_ingestion_layer/firmware/main/app/offload_app.c
+++ b/data_ingestion_layer/firmware/main/app/offload_app.c
@@ -1,0 +1,130 @@
+// offload_app.c — plug-and-play boot state machine (skeleton).
+// See docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md. Wires provisioning -> discovery ->
+// mqtt -> negotiate -> stream, and applies live config. Hardware/SDK-gated steps marked TODO.
+#include "app/offload_app.h"
+#include "net/discovery.h"
+#include "net/mqtt_client.h"
+#include "wifi_manager.h"        // existing
+#include "board_config.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include <string.h>
+
+static const char *TAG = "offload_app";
+
+void offload_app_build_capabilities(app_ctx_t *ctx) {
+    np_capabilities_t *c = &ctx->caps;
+    np_make_node_id(c->node_id, sizeof(c->node_id));
+    strncpy(ctx->node_id, c->node_id, sizeof(ctx->node_id));
+    c->firmware = NP_FW_VERSION;
+#if HAS_XVF3800
+    c->hardware = NP_HARDWARE_XVF;
+    c->provides.aec = true; c->provides.doa = true; c->provides.beamforming = true;
+#else
+    c->hardware = NP_HARDWARE_LITE;
+#endif
+    c->provides.vad = true;                  // energy VAD always available
+    c->provides.speaker_gate = false;        // not yet (server recognizes)
+    c->psram_mb = 8; c->sample_rate = 16000; c->frame_ms = 20; c->max_payload_bytes = 8192;
+    // Advertise only the features this build actually computes (edge_features). Start
+    // conservative; expand after on-device validation vs server extractors.
+    int i = 0;
+#ifdef CONFIG_EDGE_FEATURE_SNR
+    c->provides.features[i++] = NP_FEAT_SNR;
+#endif
+#ifdef CONFIG_EDGE_FEATURE_SPECTRAL_FLATNESS
+    c->provides.features[i++] = NP_FEAT_SPECTRAL_FLATNESS;
+#endif
+    c->provides.features[i] = NULL;
+}
+
+void offload_app_on_mqtt(const char *topic, const char *data, size_t len, void *user) {
+    app_ctx_t *ctx = (app_ctx_t *)user;
+    char cfg_topic[64];
+    np_topic_config(ctx->node_id, cfg_topic, sizeof(cfg_topic));
+    if (strcmp(topic, cfg_topic) == 0) {
+        np_assignment_free(&ctx->assignment);
+        if (np_parse_assignment(data, len, &ctx->assignment)) {
+            ctx->config_dirty = true;
+            ESP_LOGI(TAG, "assignment: mode=%d vad_gated=%d", ctx->assignment.mode,
+                     ctx->assignment.vad_gated);
+        }
+    }
+}
+
+static bool connect_and_negotiate(app_ctx_t *ctx) {
+    // DISCOVER_SINK: mDNS -> NVS broker -> Kconfig host.
+    discovery_result_t sink;
+    if (!discovery_find_sink(5000, ctx->prov.broker_host, ctx->prov.broker_port, &sink)) {
+        ESP_LOGW(TAG, "no broker found"); return false;
+    }
+    ESP_LOGI(TAG, "sink %s:%d (mdns=%d)", sink.host, sink.port, sink.from_mdns);
+    // Remember the broker for faster next boot (TODO: provisioning_save with updated host).
+
+    // MQTT_CONN
+    mqtt_client_cfg_t mc = {0};
+    strncpy(mc.host, sink.host, sizeof(mc.host));
+    mc.port = sink.port; mc.tls = sink.tls;
+    strncpy(mc.client_id, ctx->node_id, sizeof(mc.client_id));
+    strncpy(mc.username, ctx->prov.mqtt_user, sizeof(mc.username));
+    strncpy(mc.password, ctx->prov.mqtt_pass, sizeof(mc.password));
+    mc.on_message = offload_app_on_mqtt; mc.user = ctx;
+    if (!mqtt_client_start(&mc)) return false;
+    for (int i = 0; i < 50 && !mqtt_client_is_connected(); i++) vTaskDelay(pdMS_TO_TICKS(100));
+    if (!mqtt_client_is_connected()) return false;
+
+    // NEGOTIATE: subscribe config, publish capabilities (retained), wait for assignment.
+    char t_cfg[64], t_cap[64];
+    np_topic_config(ctx->node_id, t_cfg, sizeof(t_cfg));
+    np_topic_capabilities(ctx->node_id, t_cap, sizeof(t_cap));
+    mqtt_client_subscribe(t_cfg, 1);
+    char *adv = np_build_capabilities_json(&ctx->caps);
+    mqtt_client_publish(t_cap, adv, strlen(adv), 1, /*retain=*/true);
+    free(adv);
+    for (int i = 0; i < 100 && !ctx->assignment.valid; i++) vTaskDelay(pdMS_TO_TICKS(100));
+    return ctx->assignment.valid;  // server replied with a config
+}
+
+static void app_task(void *arg) {
+    app_ctx_t *ctx = (app_ctx_t *)arg;
+    for (;;) {
+        switch (ctx->state) {
+        case APP_BOOT:
+            if (!provisioning_load(&ctx->prov)) { ctx->state = APP_PROVISIONING; break; }
+            ctx->state = APP_WIFI_CONNECT; break;
+        case APP_PROVISIONING:
+            ESP_LOGI(TAG, "entering provisioning portal");
+            provisioning_run_portal(&ctx->prov, /*timeout_s=*/0);  // blocks until creds
+            ctx->state = APP_WIFI_CONNECT; break;
+        case APP_WIFI_CONNECT:
+            // wifi_manager already STA-connects from creds; here ensure creds applied + wait IP.
+            // TODO: wifi_manager_set_credentials(ctx->prov.wifi_ssid, ctx->prov.wifi_pass)
+            if (wifi_manager_is_connected()) ctx->state = APP_DISCOVER_SINK;
+            else vTaskDelay(pdMS_TO_TICKS(500));
+            break;
+        case APP_DISCOVER_SINK:  // DISCOVER_SINK + MQTT_CONN + NEGOTIATE
+            ctx->state = connect_and_negotiate(ctx) ? APP_STREAMING : APP_RECONNECT;
+            break;
+        case APP_STREAMING:
+            // Audio pipeline runs in i2s/vad tasks; the transport router reads ctx->assignment.
+            if (!mqtt_client_is_connected()) { ctx->state = APP_RECONNECT; break; }
+            if (ctx->config_dirty) { ctx->config_dirty = false; /* re-apply mode live */ }
+            vTaskDelay(pdMS_TO_TICKS(500));
+            break;
+        case APP_RECONNECT:
+            ESP_LOGW(TAG, "reconnecting"); mqtt_client_stop();
+            vTaskDelay(pdMS_TO_TICKS(2000));
+            ctx->state = wifi_manager_is_connected() ? APP_DISCOVER_SINK : APP_WIFI_CONNECT;
+            break;
+        default: vTaskDelay(pdMS_TO_TICKS(200));
+        }
+    }
+}
+
+void offload_app_start(app_ctx_t *ctx) {
+    ctx->state = APP_BOOT;
+    ctx->latest_doa = INT16_MIN;
+    offload_app_build_capabilities(ctx);
+    xTaskCreatePinnedToCore(app_task, "offload_app", 6144, ctx, 9, NULL, 0);
+}

--- a/data_ingestion_layer/firmware/main/app/offload_app.h
+++ b/data_ingestion_layer/firmware/main/app/offload_app.h
@@ -1,0 +1,47 @@
+// offload_app.h — the plug-and-play boot state machine that ties everything together.
+// See docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md §2.
+#pragma once
+#include "protocol/node_protocol.h"
+#include "provisioning/provisioning.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    APP_BOOT = 0,
+    APP_PROVISIONING,
+    APP_WIFI_CONNECT,
+    APP_DISCOVER_SINK,
+    APP_MQTT_CONN,
+    APP_NEGOTIATE,
+    APP_STREAMING,
+    APP_RECONNECT,
+} app_state_t;
+
+// Shared runtime state owned by the app task; read by the audio/publish tasks.
+typedef struct {
+    char node_id[40];
+    prov_config_t prov;
+    np_capabilities_t caps;     // what we advertise
+    np_assignment_t assignment; // what the server told us to do (applied live)
+    app_state_t state;
+    volatile int16_t latest_doa;       // updated by dsp_ctrl (XVF only); INT16_MIN if unknown
+    volatile bool config_dirty;        // set when a new nodes/{id}/config arrives
+} app_ctx_t;
+
+// Build the capability advertisement from board feature flags + which features this build
+// computes (board_config.h HAS_* + edge_features availability).
+void offload_app_build_capabilities(app_ctx_t *ctx);
+
+// Start the state-machine task. Pulls in wifi_manager, discovery, mqtt_client, node_protocol;
+// drives provisioning/discovery/connect/negotiate and applies assignments. The audio pipeline
+// (i2s/vad tasks) keeps running; the transport router consults ctx->assignment.mode.
+void offload_app_start(app_ctx_t *ctx);
+
+// MQTT message callback (config topic) -> parse assignment into ctx->assignment, set dirty.
+void offload_app_on_mqtt(const char *topic, const char *data, size_t len, void *user);
+
+#ifdef __cplusplus
+}
+#endif

--- a/data_ingestion_layer/firmware/main/features/edge_features.c
+++ b/data_ingestion_layer/firmware/main/features/edge_features.c
@@ -1,0 +1,39 @@
+// edge_features.c — on-node feature extraction (skeleton). SDK: esp-dsp (managed component
+// espressif/esp-dsp). Mirrors the server extractors so values are directly comparable; only
+// the cheap OFFLOADABLE features. See design doc §7 and processing_layer .../extractors/.
+#include "features/edge_features.h"
+#include <string.h>
+#include <math.h>
+// #include "esp_dsp.h"
+
+static int s_sr, s_nfft;
+
+bool edge_features_init(int sample_rate, int n_fft) {
+    s_sr = sample_rate; s_nfft = n_fft;
+    // TODO: dsps_fft2r_init_fc32(NULL, n_fft); precompute Hann window + mel filterbank
+    // (64 mels, fmax 8000) to match temporal/spectral_modulation server params.
+    return true;
+}
+
+void edge_features_compute(const int16_t *x, int count, float noise_floor,
+                           uint32_t mask, edge_features_t *out) {
+    memset(out, 0, sizeof(*out));
+
+    if (mask & EF_SNR) {
+        // Cheapest: speech energy vs the VAD's tracked noise floor (same definition the VAD uses).
+        double e = 0; for (int i = 0; i < count; i++) e += (double)x[i] * x[i];
+        float rms = sqrtf((float)(e / (count > 0 ? count : 1)));
+        out->snr = 20.0f * log10f((rms + 1e-6f) / (noise_floor + 1e-6f));
+        out->has_snr = true;
+    }
+    if (mask & EF_SPECTRAL_FLATNESS) {
+        // TODO: windowed FFT (dsps_fft2r_fc32) -> power spectrum -> geomean/aritmean.
+        // out->spectral_flatness = expf(mean(log(P))) / mean(P);  out->has_spectral_flatness = true;
+    }
+    if (mask & EF_TEMPORAL_MODULATION) {
+        // TODO: log-mel envelope -> 2-8 Hz band-pass (Butterworth) -> mean band energy.
+    }
+    if (mask & EF_SPECTRAL_MODULATION) {
+        // TODO: FFT along the mel axis of the log-mel frames -> energy at ~2 cyc/oct bin.
+    }
+}

--- a/data_ingestion_layer/firmware/main/features/edge_features.h
+++ b/data_ingestion_layer/firmware/main/features/edge_features.h
@@ -1,0 +1,34 @@
+// edge_features.h — on-node feature extraction (esp-dsp). Only the server's OFFLOADABLE
+// features (cheap, FFT/energy-based). Heavy markers (jitter/shimmer/HNR/formants/pitch,
+// embeddings) stay server-side. Validate these against the server extractors before trusting.
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    bool  has_snr;                  float snr;                 // speech vs noise-floor energy (dB)
+    bool  has_spectral_flatness;    float spectral_flatness;   // geomean/aritmean of power spectrum
+    bool  has_temporal_modulation;  float temporal_modulation; // 2-8 Hz envelope band energy
+    bool  has_spectral_modulation;  float spectral_modulation; // ~2 cyc/oct modulation energy
+} edge_features_t;
+
+// Init FFT tables / mel bank (call once). n_fft per the modulation extractors (1024).
+bool edge_features_init(int sample_rate, int n_fft);
+
+// Compute the enabled features over a speech chunk (int16 PCM). `enable_mask` selects which
+// to compute (bitwise OR of EF_* below). `noise_floor` from the VAD feeds SNR cheaply.
+#define EF_SNR                 (1u << 0)
+#define EF_SPECTRAL_FLATNESS   (1u << 1)
+#define EF_TEMPORAL_MODULATION (1u << 2)
+#define EF_SPECTRAL_MODULATION (1u << 3)
+
+void edge_features_compute(const int16_t *samples, int count, float noise_floor,
+                           uint32_t enable_mask, edge_features_t *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/data_ingestion_layer/firmware/main/net/discovery.c
+++ b/data_ingestion_layer/firmware/main/net/discovery.c
@@ -1,0 +1,34 @@
+// discovery.c — mDNS sink discovery with NVS/Kconfig fallback (skeleton).
+// SDK: components/mdns (add "mdns" to REQUIRES). See design doc §3.
+#include "net/discovery.h"
+#include <string.h>
+#include <stdio.h>
+#include "esp_log.h"
+// #include "mdns.h"
+
+static const char *TAG = "discovery";
+
+bool discovery_find_sink(int timeout_ms, const char *fallback_host, int fallback_port,
+                         discovery_result_t *out) {
+    memset(out, 0, sizeof(*out));
+    // TODO(mdns): mdns_init() once at boot; then:
+    //   mdns_result_t *r = NULL;
+    //   mdns_query_ptr(DISCOVERY_SERVICE, DISCOVERY_PROTO, timeout_ms, 10, &r);
+    //   pick first responder; out->host = ip, out->port = r->port,
+    //   out->tls = TXT "tls"=="1"; out->from_mdns = true; mdns_query_results_free(r);
+    // Below is the fallback path used when mDNS yields nothing:
+    if (fallback_host && fallback_host[0]) {
+        strncpy(out->host, fallback_host, sizeof(out->host) - 1);
+        out->port = fallback_port > 0 ? fallback_port : 1883;
+        out->from_mdns = false;
+        ESP_LOGW(TAG, "mDNS empty; using stored/compiled broker %s:%d", out->host, out->port);
+        return true;
+    }
+#ifdef CONFIG_SERVER_HOST
+    strncpy(out->host, CONFIG_SERVER_HOST, sizeof(out->host) - 1);
+    out->port = 1883;
+    return true;
+#else
+    return false;
+#endif
+}

--- a/data_ingestion_layer/firmware/main/net/discovery.h
+++ b/data_ingestion_layer/firmware/main/net/discovery.h
@@ -1,0 +1,30 @@
+// discovery.h — find the backend MQTT sink on the LAN so the server IP is never compiled in.
+//
+// Resolution order: mDNS (_iotsensing-mqtt._tcp) -> last-good broker in NVS -> compiled
+// CONFIG_SERVER_HOST. Makes the node plug-and-play across sites.
+#pragma once
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define DISCOVERY_SERVICE "_iotsensing-mqtt"
+#define DISCOVERY_PROTO   "_tcp"
+
+typedef struct {
+    char host[64];   // resolved broker IP/hostname
+    int  port;       // 1883 (or 8883 if tls)
+    bool tls;        // from mDNS TXT "tls=1"
+    bool from_mdns;  // false => came from NVS/Kconfig fallback
+} discovery_result_t;
+
+// One-shot discovery with timeout. fallback_host/port used if mDNS yields nothing
+// (pass the NVS broker_host, else "" to fall through to Kconfig). Returns true if a usable
+// broker was resolved (mDNS or fallback).
+bool discovery_find_sink(int timeout_ms, const char *fallback_host, int fallback_port,
+                         discovery_result_t *out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/data_ingestion_layer/firmware/main/net/mqtt_client.c
+++ b/data_ingestion_layer/firmware/main/net/mqtt_client.c
@@ -1,0 +1,51 @@
+// mqtt_client.c — esp-mqtt wrapper (skeleton). SDK: components/mqtt (add "mqtt" to REQUIRES).
+#include "net/mqtt_client.h"
+#include <string.h>
+#include <stdio.h>
+#include "esp_log.h"
+// #include "mqtt_client.h"  // esp-mqtt (note: same filename; include via <mqtt_client.h>)
+
+static const char *TAG = "mqtt";
+// static esp_mqtt_client_handle_t s_client;
+static bool s_connected;
+static mqtt_msg_cb_t s_cb;
+static void *s_user;
+
+// TODO(esp-mqtt): event handler.
+//  MQTT_EVENT_CONNECTED  -> s_connected = true
+//  MQTT_EVENT_DISCONNECTED -> s_connected = false  (esp-mqtt auto-reconnects)
+//  MQTT_EVENT_DATA -> if (s_cb) s_cb(event->topic, event->data, event->data_len, s_user);
+
+bool mqtt_client_start(const mqtt_client_cfg_t *cfg) {
+    s_cb = cfg->on_message; s_user = cfg->user;
+    char uri[96];
+    snprintf(uri, sizeof(uri), "%s://%s:%d", cfg->tls ? "mqtts" : "mqtt", cfg->host, cfg->port);
+    ESP_LOGI(TAG, "connecting %s as %s", uri, cfg->client_id);
+    // TODO: esp_mqtt_client_config_t mc = {
+    //   .broker.address.uri = uri,
+    //   .credentials = { .username = cfg->username, .client_id = cfg->client_id,
+    //                    .authentication.password = cfg->password },
+    //   .broker.verification.certificate = cfg->tls ? CA_PEM : NULL };
+    //   s_client = esp_mqtt_client_init(&mc);
+    //   esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, handler, NULL);
+    //   esp_mqtt_client_start(s_client);
+    return true;
+}
+
+bool mqtt_client_is_connected(void) { return s_connected; }
+
+bool mqtt_client_publish(const char *topic, const char *payload, int len, int qos, bool retain) {
+    // TODO: return esp_mqtt_client_publish(s_client, topic, payload, len, qos, retain) >= 0;
+    (void)topic; (void)payload; (void)len; (void)qos; (void)retain;
+    return s_connected;
+}
+
+bool mqtt_client_subscribe(const char *topic, int qos) {
+    // TODO: return esp_mqtt_client_subscribe(s_client, topic, qos) >= 0;
+    (void)topic; (void)qos; return s_connected;
+}
+
+void mqtt_client_stop(void) {
+    // TODO: esp_mqtt_client_stop(s_client); esp_mqtt_client_destroy(s_client);
+    s_connected = false;
+}

--- a/data_ingestion_layer/firmware/main/net/mqtt_client.h
+++ b/data_ingestion_layer/firmware/main/net/mqtt_client.h
@@ -1,0 +1,36 @@
+// mqtt_client.h — thin esp-mqtt wrapper for the offload protocol (auth, reconnect, pub/sub).
+//
+// Add `mqtt` to main/CMakeLists.txt REQUIRES. Broker comes from discovery; creds from
+// provisioning (PR #81 made the broker require auth).
+#pragma once
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Called when a subscribed message arrives (used for nodes/{id}/config).
+typedef void (*mqtt_msg_cb_t)(const char *topic, const char *data, size_t len, void *user);
+
+typedef struct {
+    char host[64];
+    int  port;
+    bool tls;              // 8883 + CA pin from flash
+    char client_id[40];    // node_id
+    char username[33];
+    char password[65];
+    mqtt_msg_cb_t on_message;
+    void *user;
+} mqtt_client_cfg_t;
+
+bool mqtt_client_start(const mqtt_client_cfg_t *cfg);  // connects + auto-reconnects
+bool mqtt_client_is_connected(void);
+// QoS1; retain for capabilities/config/status, false for voice data.
+bool mqtt_client_publish(const char *topic, const char *payload, int len, int qos, bool retain);
+bool mqtt_client_subscribe(const char *topic, int qos);
+void mqtt_client_stop(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/data_ingestion_layer/firmware/main/protocol/node_protocol.c
+++ b/data_ingestion_layer/firmware/main/protocol/node_protocol.c
@@ -1,0 +1,115 @@
+// node_protocol.c — build/parse the edge protocol JSON (cJSON, bundled with ESP-IDF).
+// Contracts mirror framework/node_capabilities.py + framework/payloads/AudioPayload.py.
+#include "protocol/node_protocol.h"
+#include <stdio.h>
+#include <string.h>
+#include "cJSON.h"
+#include "esp_mac.h"
+
+size_t np_make_node_id(char *out, size_t out_len) {
+    uint8_t mac[6] = {0};
+    esp_efuse_mac_get_default(mac);
+    return snprintf(out, out_len, "respeaker-%02x%02x%02x%02x%02x%02x",
+                    mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+char *np_build_capabilities_json(const np_capabilities_t *c) {
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "node_id", c->node_id);
+    cJSON_AddStringToObject(root, "firmware", c->firmware);
+    cJSON_AddStringToObject(root, "hardware", c->hardware);
+    cJSON_AddNumberToObject(root, "psram_mb", c->psram_mb);
+    cJSON *p = cJSON_AddObjectToObject(root, "provides");
+    cJSON_AddBoolToObject(p, "vad", c->provides.vad);
+    cJSON_AddBoolToObject(p, "aec", c->provides.aec);
+    cJSON_AddBoolToObject(p, "doa", c->provides.doa);
+    cJSON_AddBoolToObject(p, "beamforming", c->provides.beamforming);
+    cJSON_AddBoolToObject(p, "speaker_gate", c->provides.speaker_gate);
+    cJSON *feats = cJSON_AddArrayToObject(p, "features");
+    for (int i = 0; i < NP_MAX_FEATURES && c->provides.features[i]; i++)
+        cJSON_AddItemToArray(feats, cJSON_CreateString(c->provides.features[i]));
+    cJSON_AddNumberToObject(root, "sample_rate", c->sample_rate);
+    cJSON_AddNumberToObject(root, "frame_ms", c->frame_ms);
+    cJSON_AddNumberToObject(root, "max_payload_bytes", c->max_payload_bytes);
+    char *s = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    return s;  // caller frees
+}
+
+char *np_build_audio_payload_json(const char *audio_b64, const np_payload_meta_t *m) {
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "type", "audio");
+    cJSON_AddStringToObject(root, "data", audio_b64 ? audio_b64 : "");
+    cJSON_AddNumberToObject(root, "timestamp", m->timestamp);
+    cJSON_AddNumberToObject(root, "sample_rate", m->sample_rate);
+    cJSON_AddStringToObject(root, "board_id", m->board_id);
+    if (m->user_id > 0) cJSON_AddNumberToObject(root, "user_id", m->user_id);
+    if (m->environment_name) cJSON_AddStringToObject(root, "environment_name", m->environment_name);
+    if (m->system_mode) cJSON_AddStringToObject(root, "system_mode", m->system_mode);
+    if (m->doa_azimuth != INT16_MIN) cJSON_AddNumberToObject(root, "doa_azimuth", m->doa_azimuth);
+    if (m->feature_count) {
+        cJSON *pf = cJSON_AddObjectToObject(root, "provided_features");
+        for (size_t i = 0; i < m->feature_count; i++)
+            cJSON_AddNumberToObject(pf, m->feature_names[i], m->feature_values[i]);
+        cJSON_AddStringToObject(root, "node_capabilities_version", NP_FW_VERSION);
+    }
+    char *s = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    return s;
+}
+
+char *np_build_status_json(const char *node_id, np_mode_t mode, int rssi,
+                           uint32_t uptime_s, uint32_t free_heap, int16_t last_doa) {
+    static const char *MODE_S[] = {"raw", "segments", "features"};
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddStringToObject(root, "node_id", node_id);
+    cJSON_AddStringToObject(root, "mode", MODE_S[mode]);
+    cJSON_AddNumberToObject(root, "rssi", rssi);
+    cJSON_AddNumberToObject(root, "uptime_s", uptime_s);
+    cJSON_AddNumberToObject(root, "free_heap", free_heap);
+    if (last_doa != INT16_MIN) cJSON_AddNumberToObject(root, "last_doa", last_doa);
+    char *s = cJSON_PrintUnformatted(root);
+    cJSON_Delete(root);
+    return s;
+}
+
+bool np_parse_assignment(const char *json, size_t len, np_assignment_t *out) {
+    memset(out, 0, sizeof(*out));
+    cJSON *root = cJSON_ParseWithLength(json, len);
+    if (!root) return false;
+    const cJSON *mode = cJSON_GetObjectItem(root, "mode");
+    out->mode = NP_MODE_RAW;
+    if (cJSON_IsString(mode)) {
+        if (!strcmp(mode->valuestring, "features")) out->mode = NP_MODE_FEATURES;
+        else if (!strcmp(mode->valuestring, "segments")) out->mode = NP_MODE_SEGMENTS;
+    }
+    out->vad_gated = cJSON_IsTrue(cJSON_GetObjectItem(root, "vad_gated"));
+    out->raw_on_uncertain = cJSON_IsTrue(cJSON_GetObjectItem(root, "raw_on_uncertain"));
+    const cJSON *ri = cJSON_GetObjectItem(root, "report_interval_ms");
+    out->report_interval_ms = cJSON_IsNumber(ri) ? ri->valueint : 1000;
+    const cJSON *feats = cJSON_GetObjectItem(root, "features");
+    int i = 0;
+    const cJSON *f;
+    cJSON_ArrayForEach(f, feats) {
+        if (i >= NP_MAX_FEATURES || !cJSON_IsString(f)) break;
+        out->features[i++] = strdup(f->valuestring);  // freed by np_assignment_free
+    }
+    out->valid = true;
+    cJSON_Delete(root);
+    return true;
+}
+
+void np_assignment_free(np_assignment_t *a) {
+    for (int i = 0; i < NP_MAX_FEATURES && a->features[i]; i++) {
+        free((void *)a->features[i]);
+        a->features[i] = NULL;
+    }
+}
+
+size_t np_topic_capabilities(const char *id, char *o, size_t n) { return snprintf(o, n, "nodes/%s/capabilities", id); }
+size_t np_topic_config(const char *id, char *o, size_t n)       { return snprintf(o, n, "nodes/%s/config", id); }
+size_t np_topic_status(const char *id, char *o, size_t n)       { return snprintf(o, n, "nodes/%s/status", id); }
+size_t np_topic_voice(const np_payload_meta_t *m, char *o, size_t n) {
+    return snprintf(o, n, "voice/%d/%s/%s", m->user_id > 0 ? m->user_id : 0,
+                    m->board_id, m->environment_name ? m->environment_name : "default");
+}

--- a/data_ingestion_layer/firmware/main/protocol/node_protocol.h
+++ b/data_ingestion_layer/firmware/main/protocol/node_protocol.h
@@ -1,0 +1,103 @@
+// node_protocol.h — edge capability/offload protocol (firmware side).
+//
+// Mirrors the server contracts:
+//   framework/node_capabilities.py  (NodeCapabilities / NodeAssignment / OFFLOADABLE_FEATURES)
+//   framework/payloads/AudioPayload.py (+ provided_features)
+//   node_registry_service.py  (topics nodes/{id}/capabilities, nodes/{id}/config)
+//
+// Builds the JSON the node publishes and parses the assignment it receives (cJSON).
+#pragma once
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define NP_FW_VERSION "ihearyou-fw/2.0.0"
+#define NP_HARDWARE_XVF "esp32-s3+xvf3800"
+#define NP_HARDWARE_LITE "esp32-s3"
+
+// Transport modes (must match MODE_RAW/MODE_SEGMENTS/MODE_FEATURES server-side).
+typedef enum { NP_MODE_RAW = 0, NP_MODE_SEGMENTS, NP_MODE_FEATURES } np_mode_t;
+
+// The server's OFFLOADABLE_FEATURES allow-list. Advertise ONLY a subset the build computes;
+// anything else is ignored by negotiate_assignment().
+#define NP_FEAT_SNR "snr"
+#define NP_FEAT_SPECTRAL_FLATNESS "spectral_flatness"
+#define NP_FEAT_TEMPORAL_MODULATION "temporal_modulation"
+#define NP_FEAT_SPECTRAL_MODULATION "spectral_modulation"
+#define NP_MAX_FEATURES 8
+
+// What this node can do (-> "provides" in the advertisement).
+typedef struct {
+    bool vad, aec, doa, beamforming, speaker_gate;
+    const char *features[NP_MAX_FEATURES];  // names from NP_FEAT_* ; NULL-terminated
+} np_provides_t;
+
+typedef struct {
+    char node_id[40];          // "respeaker-aabbccddeeff" (eFuse MAC)
+    const char *firmware;      // NP_FW_VERSION
+    const char *hardware;      // NP_HARDWARE_*
+    int psram_mb;
+    np_provides_t provides;
+    int sample_rate;           // 16000
+    int frame_ms;              // 20
+    int max_payload_bytes;     // 8192
+} np_capabilities_t;
+
+// The assignment received on nodes/{id}/config.
+typedef struct {
+    np_mode_t mode;
+    bool vad_gated;
+    const char *features[NP_MAX_FEATURES];  // names; NULL-terminated (heap-owned copy)
+    bool raw_on_uncertain;
+    int report_interval_ms;
+    bool valid;                // false until a config message was successfully parsed
+} np_assignment_t;
+
+// Per-chunk metadata + optional node-computed features for an AudioPayload.
+typedef struct {
+    int user_id;               // <=0 => omit (server recognizes)
+    const char *board_id;      // == node_id
+    const char *environment_name;
+    const char *system_mode;   // "live"
+    double timestamp;          // unix seconds
+    int sample_rate;
+    int16_t doa_azimuth;       // from XVF3800; INT16_MIN => unknown
+    // feature mode only: parallel arrays of name/value
+    const char *feature_names[NP_MAX_FEATURES];
+    float feature_values[NP_MAX_FEATURES];
+    size_t feature_count;
+} np_payload_meta_t;
+
+// --- Identity ---------------------------------------------------------------
+// Fills node_id with "respeaker-<mac12>" from the eFuse MAC. Returns bytes written.
+size_t np_make_node_id(char *out, size_t out_len);
+
+// --- Build (returns malloc'd JSON string; caller frees) ---------------------
+// Advertisement for nodes/{id}/capabilities (retained).
+char *np_build_capabilities_json(const np_capabilities_t *caps);
+// AudioPayload for voice/{user}/{board}/{env}. For NP_MODE_FEATURES pass NULL audio_b64 and
+// set meta->feature_*; for raw/segments pass the base64 audio and feature_count = 0.
+char *np_build_audio_payload_json(const char *audio_b64, const np_payload_meta_t *meta);
+// Heartbeat for nodes/{id}/status (retained).
+char *np_build_status_json(const char *node_id, np_mode_t mode, int rssi,
+                           uint32_t uptime_s, uint32_t free_heap, int16_t last_doa);
+
+// --- Parse ------------------------------------------------------------------
+// Parse a nodes/{id}/config message into *out. Returns true on success; *out owns heap copies
+// of feature names (free with np_assignment_free).
+bool np_parse_assignment(const char *json, size_t len, np_assignment_t *out);
+void np_assignment_free(np_assignment_t *a);
+
+// Topic helpers (write into caller buffer). Return bytes written.
+size_t np_topic_capabilities(const char *node_id, char *out, size_t n);  // nodes/{id}/capabilities
+size_t np_topic_config(const char *node_id, char *out, size_t n);        // nodes/{id}/config
+size_t np_topic_status(const char *node_id, char *out, size_t n);        // nodes/{id}/status
+size_t np_topic_voice(const np_payload_meta_t *m, char *out, size_t n);  // voice/{user}/{board}/{env}
+
+#ifdef __cplusplus
+}
+#endif

--- a/data_ingestion_layer/firmware/main/provisioning/provisioning.c
+++ b/data_ingestion_layer/firmware/main/provisioning/provisioning.c
@@ -1,0 +1,63 @@
+// provisioning.c — SoftAP/BLE Wi-Fi provisioning + NVS persistence (skeleton).
+// SDK: wifi_provisioning (scheme_softap or scheme_ble), nvs_flash. See design doc §2/§8.
+#include "provisioning/provisioning.h"
+#include <string.h>
+#include <stdio.h>
+#include "esp_log.h"
+#include "nvs.h"
+// #include "wifi_provisioning/manager.h"
+// #include "wifi_provisioning/scheme_softap.h"
+
+static const char *TAG = "prov";
+static const char *NS = "ihy_prov";
+
+bool provisioning_load(prov_config_t *out) {
+    memset(out, 0, sizeof(*out));
+    nvs_handle_t h;
+    if (nvs_open(NS, NVS_READONLY, &h) != ESP_OK) return false;
+    size_t n = sizeof(out->wifi_ssid);
+    bool ok = nvs_get_str(h, "ssid", out->wifi_ssid, &n) == ESP_OK && out->wifi_ssid[0];
+    if (ok) {
+        n = sizeof(out->wifi_pass);  nvs_get_str(h, "pass", out->wifi_pass, &n);
+        n = sizeof(out->mqtt_user);  nvs_get_str(h, "muser", out->mqtt_user, &n);
+        n = sizeof(out->mqtt_pass);  nvs_get_str(h, "mpass", out->mqtt_pass, &n);
+        n = sizeof(out->broker_host); nvs_get_str(h, "broker", out->broker_host, &n);
+        int32_t v = 0;
+        if (nvs_get_i32(h, "bport", &v) == ESP_OK) out->broker_port = v;
+        if (nvs_get_i32(h, "uid", &v) == ESP_OK)   out->user_id = v;
+        n = sizeof(out->environment); nvs_get_str(h, "env", out->environment, &n);
+    }
+    nvs_close(h);
+    return ok;
+}
+
+bool provisioning_save(const prov_config_t *c) {
+    nvs_handle_t h;
+    if (nvs_open(NS, NVS_READWRITE, &h) != ESP_OK) return false;
+    nvs_set_str(h, "ssid", c->wifi_ssid);   nvs_set_str(h, "pass", c->wifi_pass);
+    nvs_set_str(h, "muser", c->mqtt_user);  nvs_set_str(h, "mpass", c->mqtt_pass);
+    nvs_set_str(h, "broker", c->broker_host); nvs_set_i32(h, "bport", c->broker_port);
+    nvs_set_i32(h, "uid", c->user_id);      nvs_set_str(h, "env", c->environment);
+    bool ok = nvs_commit(h) == ESP_OK;
+    nvs_close(h);
+    return ok;
+}
+
+void provisioning_erase(void) {
+    nvs_handle_t h;
+    if (nvs_open(NS, NVS_READWRITE, &h) == ESP_OK) { nvs_erase_all(h); nvs_commit(h); nvs_close(h); }
+}
+
+bool provisioning_run_portal(prov_config_t *out, int timeout_s) {
+    ESP_LOGI(TAG, "SoftAP portal IHearYou-Setup-XXXX (timeout=%ds)", timeout_s);
+    // TODO(wifi_provisioning): wifi_prov_mgr_init(scheme_softap); start with a service name
+    //   derived from MAC; register a custom endpoint to also collect mqtt_user/mqtt_pass/uid/env;
+    //   on WIFI_PROV_CRED_RECV fill *out; on success persist and return true.
+    //   A captive-portal page (or the ESP BLE/SoftAP provisioning apps) drives the UX.
+    (void)out; (void)timeout_s;
+    return false;  // stub
+}
+
+void provisioning_check_factory_reset(void) {
+    // TODO: poll GPIO0; if held >=5s -> provisioning_erase() + esp_restart().
+}

--- a/data_ingestion_layer/firmware/main/provisioning/provisioning.h
+++ b/data_ingestion_layer/firmware/main/provisioning/provisioning.h
@@ -1,0 +1,42 @@
+// provisioning.h — plug-and-play Wi-Fi (+ broker) provisioning with NVS persistence.
+//
+// First boot with no stored creds: bring up a SoftAP captive portal (or BLE) via ESP-IDF
+// `wifi_provisioning`, collect Wi-Fi SSID/pass (+ optional MQTT user/pass, occupant id), and
+// persist to NVS. Subsequent boots read straight from NVS -> no recompile per deployment.
+#pragma once
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    char wifi_ssid[33];
+    char wifi_pass[65];
+    char mqtt_user[33];     // optional; "" => anonymous (broker may reject, see PR #81)
+    char mqtt_pass[65];
+    char broker_host[64];   // last-good broker; "" => use discovery (mDNS)
+    int  broker_port;       // 0 => default 1883
+    int  user_id;           // occupant bound at setup; <=0 => server-side recognition
+    char environment[33];   // e.g. "livingroom"
+} prov_config_t;
+
+// Load creds from NVS. Returns true if a Wi-Fi SSID is present (i.e. already provisioned).
+bool provisioning_load(prov_config_t *out);
+// Persist creds to NVS (namespace "ihy_prov").
+bool provisioning_save(const prov_config_t *cfg);
+// Wipe stored creds (factory reset) -> next boot re-enters provisioning.
+void provisioning_erase(void);
+
+// Run the provisioning portal until creds are submitted (blocking, with timeout_s; 0 = forever).
+// SoftAP SSID is "IHearYou-Setup-XXXX" (XXXX = last 2 MAC bytes). On success fills *out and
+// also persists. Returns true if provisioned.
+bool provisioning_run_portal(prov_config_t *out, int timeout_s);
+
+// Long-press handler: call from a GPIO0 ISR/task; >=5s held -> provisioning_erase()+reboot.
+void provisioning_check_factory_reset(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md
+++ b/docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md
@@ -1,0 +1,247 @@
+# ReSpeaker Lite (ESP32-S3 + XVF3800) — Plug-and-Play Edge-Offload Firmware Design
+
+Status: **design sketch**. Extends the existing ESP-IDF firmware in
+`data_ingestion_layer/firmware/` to (a) be **plug-and-play** — flash once, power on anywhere,
+and it onboards itself — and (b) speak the **capability-negotiation + edge-offload protocol**
+already implemented server-side (PRs #82/#83/#84). Skeletons for the new components live under
+`main/{provisioning,net,protocol,features}/`.
+
+---
+
+## 1. Goals
+
+1. **Plug-and-play.** No per-deployment recompile. Flash the same binary to every node; on
+   first boot it provisions Wi-Fi, **discovers the backend sink on the LAN**, connects, and
+   starts streaming. Re-positioning a mic = unplug, move, plug back in.
+2. **Privacy-preserving edge offload.** The node advertises what it can compute on-device;
+   the server negotiates an assignment; the node sends **features** (no raw audio) when it
+   can, **VAD-gated segments** otherwise, **raw** as last resort.
+3. **Zero-touch recovery.** Lose Wi-Fi / broker / power → reconnect and resume without a human.
+4. **Build on what exists.** Keep the working I2S capture → energy-VAD → speech-gating path;
+   add MQTT transport, discovery, provisioning, the protocol, and on-node features alongside.
+
+---
+
+## 2. Plug-and-play boot flow (the core state machine)
+
+```
+        ┌─────────────┐  creds in NVS?  ┌──────────────┐  joined   ┌───────────────┐
+ power→ │  BOOT/INIT  │ ───── no ─────▶ │ PROVISIONING │ ────────▶ │  WIFI_CONNECT │
+        └─────────────┘                 │ (SoftAP/BLE) │           └───────┬───────┘
+              │ yes                      └──────────────┘                   │ got IP
+              └──────────────────────────────────────────────────────────▶ │
+                                                                            ▼
+   ┌──────────┐ assigned ┌───────────┐ broker ┌───────────┐  found  ┌───────────────┐
+   │ STREAMING│◀──config─│ NEGOTIATE │◀───────│ MQTT_CONN │◀────────│ DISCOVER_SINK │
+   └────┬─────┘          │(advertise)│  conn   └───────────┘  mDNS   └───────────────┘
+        │ link/broker lost                                     (fallback: NVS / Kconfig host)
+        └──────────────────────────────▶ back-off + reconnect ──────────────▶ (re-enter)
+```
+
+States (implemented as a small FreeRTOS state-machine task; see `app/offload_app.h`):
+
+| State | What happens | Exit |
+|---|---|---|
+| `BOOT` | NVS init, HAL/XVF3800 init, read stored creds + broker | creds present → WIFI_CONNECT; else PROVISIONING |
+| `PROVISIONING` | Bring up SoftAP `IHearYou-Setup-XXXX` (or BLE) using ESP-IDF `wifi_provisioning`; user submits Wi-Fi creds once (phone/captive portal). Persist to NVS. LED = slow blue blink | creds saved → WIFI_CONNECT |
+| `WIFI_CONNECT` | STA connect via existing `wifi_manager`; ret/backoff | got IP → DISCOVER_SINK |
+| `DISCOVER_SINK` | **mDNS** query for `_iotsensing-mqtt._tcp` → broker host:port. Fallbacks: last-good broker in NVS, then compiled `CONFIG_SERVER_HOST`. LED = cyan | resolved → MQTT_CONN |
+| `MQTT_CONN` | Connect to broker (TLS optional), auth (user/pass from provisioning or NVS) | CONNACK → NEGOTIATE |
+| `NEGOTIATE` | Publish **capabilities** (retained) to `nodes/{id}/capabilities`; subscribe `nodes/{id}/config`; wait for assignment | assignment received → STREAMING |
+| `STREAMING` | Run the audio pipeline in the assigned **mode** (raw / segments / features); periodic heartbeat. LED = green | broker/link lost → reconnect; new config → re-apply live |
+
+**Onboarding UX target:** flash → power → (one-time phone Wi-Fi setup) → green LED within ~10 s
+of seeing the network. After the first setup, power-cycles go straight BOOT→…→STREAMING.
+
+---
+
+## 3. Identity & discovery
+
+- **node_id** = stable per-board id = the eFuse MAC (`esp_efuse_mac_get_default`) formatted
+  `respeaker-aabbccddeeff`. Used as the MQTT client-id, the `nodes/{id}/…` topic segment, and
+  the registry key (matches `node_registry_service` keying on `node_id`).
+- **Sink discovery (mDNS).** The backend advertises the broker as a service the node resolves
+  at runtime, so the server IP is **never compiled in**:
+  - Service: `_iotsensing-mqtt._tcp` (port 1883), TXT `user=…` optional, `tls=0/1`.
+  - Server side: add an mDNS/Avahi advertisement next to the `mqtt` container (a tiny
+    `avahi-publish` sidecar or host Avahi service file) — documented in §11.
+  - Node: `mdns_query_ptr("_iotsensing-mqtt", "_tcp", …)` → first/strongest responder.
+  - **Fallbacks** (in order): mDNS → `broker_host` saved in NVS from last good session →
+    compiled `CONFIG_SERVER_HOST`. This keeps it working on networks without mDNS.
+
+---
+
+## 4. Protocol contracts (must match the server exactly)
+
+These mirror `framework/node_capabilities.py` + `framework/payloads/AudioPayload.py`. The
+firmware builds/parses these as JSON (cJSON, already available in ESP-IDF).
+
+### 4.1 Advertise — publish to `nodes/{id}/capabilities` (retained, QoS1)
+```json
+{
+  "node_id": "respeaker-aabbccddeeff",
+  "firmware": "ihearyou-fw/2.0.0",
+  "hardware": "esp32-s3+xvf3800",
+  "psram_mb": 8,
+  "provides": {
+    "vad": true, "aec": true, "doa": true, "beamforming": true, "speaker_gate": false,
+    "features": ["snr", "spectral_flatness", "temporal_modulation", "spectral_modulation"]
+  },
+  "sample_rate": 16000, "frame_ms": 20, "max_payload_bytes": 8192
+}
+```
+`provides` is derived from the board feature flags (`board_config.h`: `HAS_DOA_DETECTION`,
+`HAS_BEAMFORMING`, …) + which `features` the firmware build actually computes. **Only advertise
+features in the server's `OFFLOADABLE_FEATURES` allow-list** — anything else is ignored by
+`negotiate_assignment()`.
+
+### 4.2 Assignment — receive on `nodes/{id}/config` (retained)
+```json
+{ "mode": "features", "vad_gated": true,
+  "features": ["snr", "spectral_flatness"], "raw_on_uncertain": true,
+  "report_interval_ms": 1000 }
+```
+`mode ∈ {raw, segments, features}`. The node applies it **live** (no reflash).
+
+### 4.3 Data — publish to `voice/{user_id}/{board_id}/{env}`
+Same `AudioPayload` the server already parses (`ComputeMetricsHandler`). Mode-dependent:
+
+- **raw / segments:** `data` = base64 WAV/PCM (segments = VAD-gated only). No `provided_features`.
+- **features:** `data` = "" (or a tiny preview), `provided_features` = the node-computed
+  metrics. The server gap-filler (`core/gap_filler.select_tasks`) skips those extractors.
+```json
+{ "type": "audio", "timestamp": 1719400000.0, "sample_rate": 16000,
+  "board_id": "respeaker-aabbccddeeff", "user_id": 1, "environment_name": "livingroom",
+  "system_mode": "live",
+  "provided_features": { "snr": 12.4, "spectral_flatness": 0.18 },
+  "node_capabilities_version": "ihearyou-fw/2.0.0" }
+```
+`user_id`: until on-node speaker-id exists, send the node's configured occupant id (from
+provisioning) or omit and let the server recognize. DoA (read from XVF3800, currently dropped)
+rides along in metadata for scene analysis.
+
+### 4.4 Heartbeat — `nodes/{id}/status` (retained): uptime, RSSI, heap, mode, last-DoA.
+Drives the dashboard online/stale indicator (Edge Nodes page reads `last_seen`).
+
+---
+
+## 5. Component architecture (new modules in **bold**)
+
+```
+main/
+  app/offload_app.{c,h}        ** the boot state machine + task wiring (§2)
+  provisioning/provisioning.{c,h}  ** SoftAP/BLE Wi-Fi provisioning + NVS creds
+  net/discovery.{c,h}          ** mDNS sink discovery (+ NVS/Kconfig fallback)
+  net/mqtt_client.{c,h}        ** esp-mqtt wrapper: auth, pub/sub, reconnect, the topics
+  protocol/node_protocol.{c,h} ** build capabilities/payload JSON, parse assignment (cJSON)
+  features/edge_features.{c,h} ** on-node feature extraction (esp-dsp): snr, flatness, modulations
+  audio/   (exists)            -- I2S capture, ring buffer, energy VAD, quality  [reuse]
+  drivers/xvf3800/ (exists)    -- I2C control + DoA  [needs real packet protocol, §9]
+  network/wifi_manager.* (exists) -- STA connect/reconnect  [reuse]
+  network/tcp_client.*  (exists) -- legacy raw-TCP path  [keep as a transport fallback]
+  config, hal, system          -- [reuse]
+```
+
+Transport is selected by the assignment: a **transport router** sits where `tcp_sender` is
+today, fanning the speech queue to the MQTT publisher (raw/segments/features) or the legacy TCP
+sender. The VAD decision (already centralized in the VAD task) stays the single speech gate.
+
+---
+
+## 6. Task layout (extends the current 5-task design)
+
+| Task | Core | Prio | Role |
+|---|---|---|---|
+| `i2s_capture` | 1 | 24 | unchanged — I2S DMA → ring buffer |
+| `vad_proc` | 1 | 20 | unchanged — energy VAD gates speech into chunks |
+| **`feature_proc`** | 1 | 12 | when mode=features: compute edge features per chunk (esp-dsp) |
+| **`mqtt_pub`** | 0 | 10 | dequeue chunks → build AudioPayload (per mode) → publish |
+| **`offload_app`** | 0 | 9 | the state machine: provision/discover/connect/negotiate, apply config |
+| `dsp_ctrl` (XVF) | 0 | 8 | read DoA every 100 ms → shared `latest_doa` (now actually stored) |
+| **`heartbeat`** | 0 | 3 | replaces telemetry log: publish `nodes/{id}/status` |
+
+Core-1 stays the real-time audio core; networking/protocol on Core-0. `feature_proc` at prio
+12 yields to VAD (20) so capture is never starved; budget ~5–10 ms/chunk for the cheap features.
+
+---
+
+## 7. On-node feature extraction (`features/edge_features`)
+
+Compute **only** the server's `OFFLOADABLE_FEATURES` (cheap, FFT/energy-based, S3-feasible):
+
+| Feature | Method on S3 | Notes |
+|---|---|---|
+| `snr` | speech-frame energy vs noise-floor (the VAD already tracks both) | nearly free — reuse `vad` state |
+| `spectral_flatness` | geomean/aritmean of `esp_dsp` FFT power spectrum | one `dsps_fft2r` per frame |
+| `temporal_modulation` | 2–8 Hz band energy of the log-mel envelope | needs a small mel bank + IIR band-pass |
+| `spectral_modulation` | FFT along the mel axis at ~2 cyc/oct | reuse the mel frames |
+
+Use `esp-dsp` (`dsps_fft2r_fc32`, windowing, mel). **Validate on-device values against the
+server extractors before trusting them** (publish both for a calibration period; compare).
+Heavier markers (jitter/shimmer/HNR/formants/pyin-F0, speaker embeddings) **stay server-side** —
+the node never claims them, so the gap-filler keeps computing them from segments.
+
+---
+
+## 8. Security
+
+- **Wi-Fi creds**: entered once via provisioning, stored in **NVS** (encrypted-flash recommended).
+- **MQTT auth**: username/password — matches the broker auth from PR #81. Provisioned alongside
+  Wi-Fi (the setup portal collects broker user/pass) or carried in the mDNS TXT + a per-site
+  shared secret. Stored in NVS.
+- **TLS** (recommended for non-trusted LANs): `esp-mqtt` over 8883 with the broker CA pinned in
+  flash; mDNS TXT `tls=1` flips transport. Mosquitto side: add a `listener 8883` + certs.
+- **Topic ACLs** (broker): restrict each node to `nodes/{id}/#` and `voice/#` publish — a
+  mosquitto ACL file keyed by username. Prevents a rogue node impersonating others.
+- **Factory reset**: long-press BOOT (GPIO0) ≥5 s → wipe NVS creds → re-enter PROVISIONING.
+
+---
+
+## 9. The hard dependency: real XVF3800 control protocol
+
+The current driver uses a **fabricated flat register map** (`xvf3800.h` `0x00–0x72`) that will
+not work on silicon. The real XVF3800 uses a **packetized resource-id / command-id I2C protocol**
+(correctly described in `UNIFIED_FIRMWARE_DESIGN.md:451-491`). Before any on-hardware bring-up:
+- Reimplement `xvf3800_i2c` as `xvf_read_control(resource, cmd, *buf, len)` /
+  `xvf_write_control(...)` per XMOS's control protocol + the ReSpeaker control map.
+- Wire real ops: AEC enable/freeze/reset (currently missing), beamforming mode/direction, DoA
+  read (`xvf3800_get_doa` exists but against fake regs), hardware-VAD read (unused).
+- I2S stays 16 kHz mono (32-bit on the wire → 16-bit) — that part is sound.
+
+This is the single biggest correctness gap and is **hardware-gated** (needs the board + a logic
+analyzer). Everything in §2–§8 can be developed/CI-built without it; mark XVF calls behind
+`HAS_XVF3800` so the Lite (codec-only) build runs the full plug-n-play + offload path today.
+
+---
+
+## 10. Phased implementation plan
+
+1. **P1 — Plug-and-play transport (no XVF needed):** add `provisioning`, `discovery`,
+   `mqtt_client`, `node_protocol`; route the existing speech-gated chunks to MQTT in
+   `segments` mode; advertise capabilities (vad only). Outcome: flash a **Lite** board, set
+   Wi-Fi once, it auto-finds the broker and appears on the Edge Nodes dashboard, streaming
+   VAD-gated segments. *Fully testable on current hardware.*
+2. **P2 — Features mode:** add `edge_features` (snr, spectral_flatness first), advertise them,
+   honor `mode=features`, run the calibration cross-check vs server extractors.
+3. **P3 — XVF3800 real protocol:** reimplement the control layer (§9); advertise aec/doa/
+   beamforming; feed DoA + AEC reference; flip to the XVF board build.
+4. **P4 — Hardening:** TLS, broker ACLs, encrypted NVS, OTA (partitions already support it),
+   factory-reset button, watchdog coverage of the new tasks.
+
+---
+
+## 11. Server-side companions (small, separate work)
+
+- **mDNS advertisement** for the broker so nodes can discover it (host Avahi `.service` file or
+  a sidecar container advertising `_iotsensing-mqtt._tcp` on 1883).
+- **Provisioning occupant mapping** (optional): a way to bind a node_id → user_id/environment
+  at setup time (the Edge Nodes dashboard page is the natural home for this).
+- Broker **ACL file** keyed by node username (security §8).
+
+---
+
+## 12. What this buys
+
+Flash-and-forget nodes that self-onboard, send **features instead of raw audio** wherever the
+S3 can compute them (raw PHI never leaves the room), fall back gracefully on weaker nodes, and
+show up live on the dashboard — all negotiated, no per-node configuration.


### PR DESCRIPTION
A **design sketch** (not buildable firmware) extending the existing ESP-IDF firmware to be **plug-and-play** and to speak the edge-offload protocol from #82/#83/#84.

## Plug-and-play
Flash once, power on anywhere → the node provisions Wi-Fi (one-time phone setup), **discovers the backend over mDNS** (server IP never compiled in), connects to MQTT, advertises its capabilities, gets an assignment, and streams. Re-positioning = unplug/move/replug. Boot state machine in `app/offload_app`.

## Speaks the server protocol exactly
`protocol/node_protocol.{h,c}` builds/parses the **same JSON contracts** as the server (`node_capabilities.py`, `AudioPayload`, topics `nodes/{id}/{capabilities,config,status}`, `voice/{u}/{b}/{e}`) — the cJSON build/parse is concrete, not stubbed.

## What's here
- `docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md` — full design: boot flow, contracts, task layout, on-node features, security, 4-phase plan.
- Component skeletons (headers = real interfaces, `.c` = documented stubs w/ SDK refs + TODOs): `provisioning` (SoftAP/BLE + NVS), `net/discovery` (mDNS + fallback), `net/mqtt_client` (esp-mqtt + auth), `features/edge_features` (esp-dsp), `app/offload_app` (state machine).
- `main/CMakeLists.txt` wired (REQUIRES mqtt/mdns/wifi_provisioning/json).

## Honest caveats
- Headers syntax-checked; **not buildable** without ESP-IDF + hardware (expected for a sketch).
- The existing **XVF3800 driver uses a fabricated register map** — real silicon needs the packetized resource/command protocol (design §9). **P1 (plug-and-play + VAD-gated segments) needs no XVF3800** and is implementable on a Lite board today.
- Server companion needed: an mDNS advertisement for the broker (design §11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)