### PR TITLE
Broker mDNS advertisement (plug-and-play sink discovery)

### DIFF
--- a/deploy/mdns/README.md
+++ b/deploy/mdns/README.md
@@ -1,0 +1,23 @@
+# Broker mDNS advertisement (plug-and-play sink discovery)
+
+Edge nodes (firmware `net/discovery.c`) resolve the backend MQTT broker at runtime via mDNS
+(`_iotsensing-mqtt._tcp`) so the **server IP is never compiled into the firmware** — flash a
+node anywhere and it finds the sink. Fallbacks if mDNS is unavailable: a broker host saved in
+the node's NVS, then the compiled `CONFIG_SERVER_HOST`.
+
+## Install (on the broker host)
+```bash
+deploy/mdns/setup_mdns.sh
+```
+
+## Two prerequisites (not auto-applied — your call)
+1. **Avahi running** — `sudo apt-get install -y avahi-daemon && sudo systemctl enable --now avahi-daemon`.
+2. **Broker reachable on the LAN** — `docker-compose.yml` binds MQTT to `127.0.0.1:1883`
+   (PHI safety). Nodes are on the LAN, so for them to connect you must change that to
+   `1883:1883`. Authentication is already enforced (PR #81); add broker ACLs (per-node
+   username → `nodes/{id}/#` + `voice/#`) before exposing, and consider TLS (8883).
+
+## How it ties together
+node boots → joins Wi-Fi → mDNS query `_iotsensing-mqtt._tcp` → broker host:port → MQTT
+connect (auth) → advertise capabilities → receive assignment → stream. See
+`docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md`.

--- a/deploy/mdns/iotsensing-mqtt.service
+++ b/deploy/mdns/iotsensing-mqtt.service
@@ -1,0 +1,12 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<!-- Advertises the IHearYou MQTT broker on the LAN so plug-and-play edge nodes discover it
+     (no compiled-in server IP). Install to /etc/avahi/services/ on the broker host. -->
+<service-group>
+  <name replace-wildcards="yes">IHearYou MQTT sink on %h</name>
+  <service>
+    <type>_iotsensing-mqtt._tcp</type>
+    <port>1883</port>
+    <txt-record>tls=0</txt-record>
+  </service>
+</service-group>

--- a/deploy/mdns/setup_mdns.sh
+++ b/deploy/mdns/setup_mdns.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Advertise the MQTT broker on the LAN as _iotsensing-mqtt._tcp so plug-and-play edge nodes
+# (firmware net/discovery.c) find it without a compiled-in IP.
+#
+# PREREQUISITES (deliberately NOT auto-applied -- both are deployment/security decisions):
+#   1. avahi-daemon installed + running:
+#        sudo apt-get install -y avahi-daemon && sudo systemctl enable --now avahi-daemon
+#   2. the MQTT broker reachable on the LAN (NOT only 127.0.0.1). The compose binds it to
+#        127.0.0.1:1883 for PHI safety; exposing it to the LAN means changing that to
+#        "1883:1883". Auth is required (PR #81) and broker ACLs are recommended before doing so.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+sudo install -m 644 "$HERE/iotsensing-mqtt.service" /etc/avahi/services/iotsensing-mqtt.service
+sudo systemctl reload avahi-daemon 2>/dev/null || sudo systemctl restart avahi-daemon
+echo "Advertised _iotsensing-mqtt._tcp on the LAN."
+echo "Verify from another host:  avahi-browse -rt _iotsensing-mqtt._tcp"


### PR DESCRIPTION
Phase-1 server companion for edge offload: advertises the MQTT broker as `_iotsensing-mqtt._tcp` so plug-and-play nodes discover it at runtime (no compiled-in IP). Adds the Avahi service file + `setup_mdns.sh` + README. The two prerequisites — enable avahi-daemon, and LAN-expose the auth'd broker (compose binds it to 127.0.0.1 for PHI safety) — are documented but **not auto-applied** (security decisions). Ties into `docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)