### PR TITLE
Pin system_mode at node enrollment (close mode-spoofing)

### DIFF
--- a/processing_layer/metrics_computation/voice_metrics/adapters/outbound/NodeEnrollmentAdapter.py
+++ b/processing_layer/metrics_computation/voice_metrics/adapters/outbound/NodeEnrollmentAdapter.py
@@ -1,0 +1,42 @@
+"""Resolves an edge node's enrolled system_mode (pinned at enrollment by scripts/enroll_node.sh).
+
+SECURITY: a per-node MQTT credential is ACL-restricted to its own topics, so board_id (taken
+from the topic) is authenticated identity. Binding system_mode to that identity here lets the
+server IGNORE the payload's system_mode for enrolled nodes -- a live node can't claim
+"dataset" to poison the research DB. Unenrolled publishers (the trusted service-account dataset
+injector) fall through to the payload mode.
+
+Reads the global iotsensing.node_enrollments collection, cached with a short TTL to avoid a
+Mongo round-trip per message.
+"""
+import os
+import time
+
+from pymongo import MongoClient
+
+
+class NodeEnrollmentAdapter:
+    def __init__(self, mongo_url=None, ttl_seconds: int = 60):
+        mongo_url = mongo_url or os.getenv("MONGO_URL", "mongodb://mongodb:27017")
+        self.collection = MongoClient(mongo_url)["iotsensing"]["node_enrollments"]
+        self.ttl = ttl_seconds
+        self._cache = {}  # node_id -> (mode_or_None, expiry_ts)
+
+    def get_mode(self, node_id):
+        """Return the enrolled system_mode for node_id, or None if not enrolled/unknown."""
+        if not node_id:
+            return None
+        now = time.time()
+        cached = self._cache.get(node_id)
+        if cached and cached[1] > now:
+            return cached[0]
+        mode = None
+        try:
+            doc = self.collection.find_one({"node_id": node_id}, {"system_mode": 1, "_id": 0})
+            if doc:
+                mode = doc.get("system_mode")
+        except Exception as e:  # never block ingestion on a registry hiccup
+            print(f"NodeEnrollmentAdapter lookup failed for '{node_id}': {e}")
+            return None
+        self._cache[node_id] = (mode, now + self.ttl)
+        return mode

--- a/processing_layer/metrics_computation/voice_metrics/core/use_cases/ComputeMetricsUseCase.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/use_cases/ComputeMetricsUseCase.py
@@ -4,10 +4,13 @@ import csv
 
 
 class ComputeMetricsUseCase:
-    def __init__(self, user_profiling, persistence, metrics_computation_service):
+    def __init__(self, user_profiling, persistence, metrics_computation_service,
+                 enrollment=None):
         self.user_profiling = user_profiling
         self.persistence = persistence
         self.metrics_computation_service = metrics_computation_service
+        # Optional: resolves an enrolled node's pinned system_mode (NodeEnrollmentAdapter).
+        self.enrollment = enrollment
 
         # logging performance measurements
         self.log_path = "performance_log.csv"
@@ -21,6 +24,15 @@ class ComputeMetricsUseCase:
 
     def execute(self, audio_bytes: bytes, metadata: dict = None):
         metadata = metadata or {}
+
+        # SECURITY: if board_id (taken from the ACL-enforced topic) is an ENROLLED edge node,
+        # its system_mode is pinned at enrollment -> ignore the payload's system_mode so a live
+        # node can't route its records into the dataset/demo DB. Unenrolled publishers (the
+        # trusted service-account dataset injector) keep the payload mode.
+        if self.enrollment is not None:
+            enrolled_mode = self.enrollment.get_mode(metadata.get("board_id"))
+            if enrolled_mode:
+                metadata["system_mode"] = enrolled_mode
 
         # Use user_id from metadata if provided, otherwise recognize from audio
         if metadata.get("user_id"):

--- a/processing_layer/metrics_computation/voice_metrics/init.py
+++ b/processing_layer/metrics_computation/voice_metrics/init.py
@@ -5,6 +5,7 @@ from adapters.inbound.MqttConsumerAdapter import (
 )
 from adapters.outbound.RestUserProfilingAdapter import RestUserProfilingAdapter
 from adapters.outbound.MongoPersistenceAdapter import MongoPersistenceAdapter
+from adapters.outbound.NodeEnrollmentAdapter import NodeEnrollmentAdapter
 from core.use_cases.ComputeMetricsUseCase import ComputeMetricsUseCase
 from core.MetricsComputationService import MetricsComputationService
 from adapters.inbound.handlers.ComputeMetricsHandler import ComputeMetricsHandler
@@ -19,9 +20,10 @@ if _mqtt_user:
 user_profiling = RestUserProfilingAdapter()
 persistence = MongoPersistenceAdapter()
 metrics_computation_service = MetricsComputationService()
+enrollment = NodeEnrollmentAdapter()
 
 comput_metrics_use_case = ComputeMetricsUseCase(
-    user_profiling, persistence, metrics_computation_service
+    user_profiling, persistence, metrics_computation_service, enrollment=enrollment
 )
 mqtt_adapter = MqttConsumerAdapter(client)
 

--- a/processing_layer/metrics_computation/voice_metrics/tests/test_enrollment_mode.py
+++ b/processing_layer/metrics_computation/voice_metrics/tests/test_enrollment_mode.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.use_cases.ComputeMetricsUseCase import ComputeMetricsUseCase
+
+
+class FakeEnroll:
+    def __init__(self, mapping):
+        self.mapping = mapping
+
+    def get_mode(self, node_id):
+        return self.mapping.get(node_id)
+
+
+class FakeMetrics:
+    def __init__(self):
+        self.last_meta = None
+
+    def compute(self, audio, user_id, metadata=None):
+        self.last_meta = metadata
+        return ([], {})  # (raw_metrics_list, quality_record without metrics_data)
+
+
+class FakePersist:
+    def save_metrics(self, x): pass
+    def save_audio_quality_metrics(self, x): pass
+
+
+class FakeProfiling:
+    def recognize_user(self, b): return 1
+
+
+def _run(monkeypatch, tmp_path, enrollment, metadata):
+    monkeypatch.chdir(tmp_path)  # ComputeMetricsUseCase writes performance_log.csv in cwd
+    fm = FakeMetrics()
+    uc = ComputeMetricsUseCase(FakeProfiling(), FakePersist(), fm, enrollment=enrollment)
+    uc.execute(b"audio", metadata)
+    return fm.last_meta
+
+
+def test_enrolled_mode_overrides_payload(monkeypatch, tmp_path):
+    meta = _run(monkeypatch, tmp_path, FakeEnroll({"node-x": "live"}),
+                {"board_id": "node-x", "user_id": 5, "system_mode": "dataset"})
+    assert meta["system_mode"] == "live"  # enrolled mode wins over spoofed payload
+
+
+def test_unenrolled_keeps_payload_mode(monkeypatch, tmp_path):
+    meta = _run(monkeypatch, tmp_path, FakeEnroll({}),
+                {"board_id": "injector", "user_id": 5, "system_mode": "dataset"})
+    assert meta["system_mode"] == "dataset"  # trusted injector keeps its mode
+
+
+def test_no_resolver_keeps_payload(monkeypatch, tmp_path):
+    meta = _run(monkeypatch, tmp_path, None,
+                {"board_id": "any", "user_id": 5, "system_mode": "demo"})
+    assert meta["system_mode"] == "demo"

--- a/scripts/enroll_node.sh
+++ b/scripts/enroll_node.sh
@@ -2,20 +2,24 @@
 # Enroll an edge node: create a per-node MQTT credential that the broker ACL restricts to the
 # node's OWN topics, so it can publish only its own data and cannot spoof another node or user.
 #
-# Usage: scripts/enroll_node.sh <node_id> <user_id>
-#   node_id   the board's id, e.g. respeaker-aabbccddeeff (also the MQTT username)
-#   user_id   the occupant this node captures for (int for dataset, uuid for live)
+# Usage: scripts/enroll_node.sh <node_id> <user_id> [system_mode]
+#   node_id      the board's id, e.g. respeaker-aabbccddeeff (also the MQTT username)
+#   user_id      the occupant this node captures for (int for dataset, uuid for live)
+#   system_mode  live|dataset|demo, default live -- PINNED server-side so the node's records
+#                always route to this DB regardless of what its payload claims.
 #
 # Enter the printed MQTT_USER/MQTT_PASS into the node's provisioning portal. Re-running for the
 # same node_id rotates the password (and keeps the existing ACL).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-NODE_ID="${1:?usage: enroll_node.sh <node_id> <user_id>}"
-USER_ID="${2:?usage: enroll_node.sh <node_id> <user_id>}"
+NODE_ID="${1:?usage: enroll_node.sh <node_id> <user_id> [system_mode]}"
+USER_ID="${2:?usage: enroll_node.sh <node_id> <user_id> [system_mode]}"
+MODE="${3:-live}"
 
 # node_id becomes an MQTT username AND a topic segment -> restrict its charset.
 [[ "$NODE_ID" =~ ^[A-Za-z0-9_-]+$ ]] || { echo "node_id must match [A-Za-z0-9_-]+"; exit 1; }
+case "$MODE" in live|dataset|demo) ;; *) echo "system_mode must be live|dataset|demo"; exit 1;; esac
 [ -f mosquitto.passwd ] || { echo "run scripts/setup_mqtt_auth.sh first"; exit 1; }
 
 PASS="$(openssl rand -hex 16)"
@@ -44,7 +48,22 @@ if [ -n "$MQTT_CTR" ]; then
   docker exec "$MQTT_CTR" kill -HUP 1 2>/dev/null || true
 fi
 
-echo "Enrolled node '${NODE_ID}' for user_id '${USER_ID}'. Credentials (enter in provisioning):"
+# Pin the node's system_mode in iotsensing.node_enrollments so voice_metrics routes its records
+# to this DB regardless of the payload (creds passed via env, never string-interpolated).
+set -a; [ -f .env ] && . ./.env; set +a
+if docker ps --format '{{.Names}}' | grep -q '^mongodb$'; then
+  docker exec -e N="$NODE_ID" -e U="$USER_ID" -e M="$MODE" mongodb mongosh --quiet \
+    ${MONGO_USER:+-u "$MONGO_USER" -p "$MONGO_PASS" --authenticationDatabase admin} iotsensing --eval '
+      db.node_enrollments.updateOne({node_id: process.env.N},
+        {$set: {node_id: process.env.N, user_id: process.env.U, system_mode: process.env.M}},
+        {upsert: true});
+      print("enrollment pinned: " + process.env.N + " -> system_mode=" + process.env.M);
+    ' || echo "WARN: could not write node_enrollments (is mongodb up + creds in .env?)"
+else
+  echo "WARN: mongodb container not running; system_mode binding NOT written. Re-run with the stack up."
+fi
+
+echo "Enrolled node '${NODE_ID}' for user_id '${USER_ID}' (system_mode=${MODE}). Credentials (enter in provisioning):"
 echo "  MQTT_USER=${NODE_ID}"
 echo "  MQTT_PASS=${PASS}"
 echo "Scope: publish voice/${USER_ID}/${NODE_ID}/# + nodes/${NODE_ID}/{capabilities,status}; subscribe nodes/${NODE_ID}/config."


### PR DESCRIPTION
The last edge spoofing vector from the bug hunt: payload `system_mode` chose the destination DB, so a live node could claim `dataset` and poison the research dataset (or write PHI into demo).

## Fix
`system_mode` is now **bound at enrollment**, not taken from the payload, for enrolled nodes:
- `scripts/enroll_node.sh <node_id> <user_id> [system_mode]` pins `node_id → system_mode` in `iotsensing.node_enrollments` (default `live`, enum-validated).
- `NodeEnrollmentAdapter` — cached lookup (TTL 60s).
- `ComputeMetricsUseCase` — if `board_id` (from the **ACL-enforced topic**, #88) is enrolled, its enrolled mode **overrides** the payload `system_mode`. Unenrolled publishers (the trusted service-account dataset injector) keep the payload mode, so that flow is unaffected.

## Validated
- 3 unit tests (enrolled overrides / unenrolled keeps / no-resolver keeps).
- **E2E on the live stack:** node enrolled `demo`, payload **claimed `dataset`** → **49 records in `iotsensing_demo`, 0 in `iotsensing_dataset`**. A separate `live`-enrolled run showed the override to `live` correctly engaging the live-only scene gatekeeper.

This completes the edge trust model (#87 feature allow-list, #88 per-node ACLs + topic identity, this PR mode binding): an edge node is now fully constrained — its own user/board, its own registry entry, only trusted features, and a fixed system_mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)