### PR TITLE
fix(temporal): time-aware robust EMA, local-day bucketing, backfill, evidence bookkeeping

### DIFF
--- a/temporal_context_modeling_layer/adapters/outbound/MongoPersistenceAdapter.py
+++ b/temporal_context_modeling_layer/adapters/outbound/MongoPersistenceAdapter.py
@@ -177,6 +177,10 @@ class MongoPersistenceAdapter(PersistencePort):
                     "metric_name": doc["metric_name"],
                     "aggregated_value": doc["aggregated_value"],
                     "system_mode": doc.get("system_mode", system_mode),
+                    # Evidence-quality fields; None on legacy records written before
+                    # sample bookkeeping existed.
+                    "sample_count": doc.get("sample_count"),
+                    "sample_std": doc.get("sample_std"),
                 })
         return all_records
 

--- a/temporal_context_modeling_layer/core/models/AggregatedMetricRecord.py
+++ b/temporal_context_modeling_layer/core/models/AggregatedMetricRecord.py
@@ -11,6 +11,10 @@ class AggregatedMetricRecord:
     metric_name: str
     aggregated_value: float
     system_mode: Optional[str] = None
+    # Per-day evidence quality: how many raw utterances the daily mean is built from and
+    # their spread. None on legacy records written before these fields existed.
+    sample_std: Optional[float] = None
+    sample_count: Optional[int] = None
 
     def to_dict(self):
         ts = self.timestamp
@@ -30,4 +34,7 @@ class AggregatedMetricRecord:
         }
         if self.system_mode is not None:
             result["system_mode"] = self.system_mode
+        if self.sample_count is not None:
+            result["sample_count"] = self.sample_count
+            result["sample_std"] = self.sample_std
         return result

--- a/temporal_context_modeling_layer/core/services/aggregate_metrics.py
+++ b/temporal_context_modeling_layer/core/services/aggregate_metrics.py
@@ -1,12 +1,24 @@
+import os
+import math
 import pandas as pd
-from typing import List
+from typing import List, Optional
 from core.models.RawMetricRecord import RawMetricRecord
 from core.models.AggregatedMetricRecord import AggregatedMetricRecord
 
 
-def aggregate_metrics(records: List[RawMetricRecord]) -> List[AggregatedMetricRecord]:
+def aggregate_metrics(
+    records: List[RawMetricRecord], tz: Optional[str] = None
+) -> List[AggregatedMetricRecord]:
     if not records:
         return []
+
+    # A user's "day" is a LOCAL calendar day. Raw timestamps are stored naive-UTC, so
+    # bucketing directly on them splits late-evening speech across two days for any
+    # deployment east/west of UTC and smears diurnal structure. TEMPORAL_TZ (IANA name,
+    # e.g. "Europe/Zurich") selects the deployment timezone; default UTC preserves the
+    # historical behavior for existing data. Stored timestamps are the local midnight,
+    # naive (consistent with the rest of the chain, which treats timestamps as naive).
+    tz = tz or os.getenv("TEMPORAL_TZ", "UTC")
 
     df = pd.DataFrame(
         {
@@ -21,15 +33,23 @@ def aggregate_metrics(records: List[RawMetricRecord]) -> List[AggregatedMetricRe
     df["metric_value"] = pd.to_numeric(df["metric_value"], errors="coerce")
     df = df.dropna(subset=["metric_value"])
 
-    # Aggregate per DAY: floor the timestamp to the day so multiple utterances on the same
-    # day collapse into one daily mean. Previously the groupby keyed on the full
-    # (microsecond) timestamp, so every record formed its own group and the "daily mean"
-    # was a no-op (output 1:1 with input).
-    df["timestamp"] = pd.to_datetime(df["timestamp"]).dt.floor("D")
+    # Aggregate per LOCAL DAY: interpret stored timestamps as UTC, convert to the
+    # deployment tz, floor to the day, then drop the tzinfo (naive local midnight).
+    # Previously the groupby keyed on the full (microsecond) timestamp, so every record
+    # formed its own group and the "daily mean" was a no-op (output 1:1 with input).
+    df["timestamp"] = (
+        pd.to_datetime(df["timestamp"], utc=True)
+        .dt.tz_convert(tz)
+        .dt.floor("D")
+        .dt.tz_localize(None)
+    )
 
+    # Keep the per-day dispersion and sample count alongside the mean: a 1-utterance day
+    # and a 300-utterance day are NOT equally reliable evidence, and downstream consumers
+    # (min-n gating, EMA weighting, reviewers) need n and spread to judge that.
     grouped = (
         df.groupby(["user_id", "timestamp", "metric_name", "system_mode"])["metric_value"]
-        .mean()
+        .agg(["mean", "std", "count"])
         .reset_index()
     )
 
@@ -38,8 +58,12 @@ def aggregate_metrics(records: List[RawMetricRecord]) -> List[AggregatedMetricRe
             user_id=row["user_id"],
             timestamp=row["timestamp"].to_pydatetime(),
             metric_name=row["metric_name"],
-            aggregated_value=float(row["metric_value"]),
+            aggregated_value=float(row["mean"]),
             system_mode=row["system_mode"],
+            # std is NaN for n == 1 (ddof=1); store None rather than a fake 0.0 --
+            # a single sample carries no dispersion information.
+            sample_std=None if (isinstance(row["std"], float) and math.isnan(row["std"])) else float(row["std"]),
+            sample_count=int(row["count"]),
         )
         for _, row in grouped.iterrows()
     ]

--- a/temporal_context_modeling_layer/core/services/temporal_context/Contextualizer.py
+++ b/temporal_context_modeling_layer/core/services/temporal_context/Contextualizer.py
@@ -1,8 +1,15 @@
 from abc import ABC, abstractmethod
-from typing import List
+from typing import List, Optional, Sequence
 
 
 class Contextualizer(ABC):
     @abstractmethod
-    def compute(self, values: List[float]) -> List[float]:
+    def compute(
+        self, values: List[float], timestamps: Optional[Sequence] = None
+    ) -> List[float]:
+        """Return a smoothed/contextual baseline for `values`.
+
+        `timestamps` (datetime-like, same length, ascending) lets implementations weight
+        updates by real elapsed time; implementations that cannot use it must accept and
+        ignore it."""
         pass

--- a/temporal_context_modeling_layer/core/services/temporal_context/HMM.py
+++ b/temporal_context_modeling_layer/core/services/temporal_context/HMM.py
@@ -1,16 +1,29 @@
 from core.services.temporal_context.Contextualizer import Contextualizer
-from typing import List
+from typing import List, Optional, Sequence
 from hmmlearn.hmm import GaussianHMM
+import logging
 import numpy as np
 
 
 class HMM(Contextualizer):
+    """WARNING -- not reproducible across a growing history: the GaussianHMM is re-fit
+    from scratch on the full series every call, so as new days arrive EM converges to
+    different parameters/state labels and PAST days' baseline values mutate between runs
+    (upserts overwrite them). Do not use for longitudinal deployments or published
+    numbers; kept only for exploratory comparison. Ignores `timestamps` (index-spaced)."""
+
     def __init__(self, n_states: int = 5, n_iter: int = 200, random_state: int = 42):
         self.n_states = n_states
         self.n_iter = n_iter
         self.random_state = random_state
 
-    def compute(self, values: List[float]) -> List[float]:
+    def compute(
+        self, values: List[float], timestamps: Optional[Sequence] = None
+    ) -> List[float]:
+        logging.warning(
+            "HMM contextualizer is non-reproducible on growing histories and ignores "
+            "calendar time; use method='ema' for deployments and published results."
+        )
         if not values or len(values) < self.n_states:
             return values
 

--- a/temporal_context_modeling_layer/core/services/temporal_context/SpikeDampenedEMA.py
+++ b/temporal_context_modeling_layer/core/services/temporal_context/SpikeDampenedEMA.py
@@ -1,46 +1,101 @@
 from core.services.temporal_context.Contextualizer import Contextualizer
-from typing import List
+from typing import List, Optional, Sequence
 
 import numpy as np
 
+# scale factor that makes the MAD a consistent estimator of the standard deviation
+MAD_TO_STD = 1.4826
+
 
 class SpikeDampenedEMA(Contextualizer):
-    """EMA that dampens steps which are large relative to the series' OWN variability.
+    """Robust, time-aware EMA: a Hampel filter for isolated outliers + a calendar-time EMA.
 
-    The spike threshold is a multiple of the typical day-to-day step (the median absolute
-    consecutive delta), not a fraction of the current value's magnitude. The old
-    `ratio * abs(value)` threshold was scale- and sign-dependent: it never fired for large
-    values (their own magnitude set a large threshold) and dampened every normal step for
-    metrics centered on zero (threshold ~0). `spike_multiplier` keeps the legacy-ish
-    `spike_threshold_ratio` name for back-compat but is now a multiplier on the typical step.
+    Two flaws of the previous implementation are fixed here:
+
+    1. It smoothed over the OBSERVATION INDEX, not calendar time. Gap days were dropped
+       before compute(), so alpha=0.13 meant "a ~14-sample window", which equals ~14 days
+       only for users who speak every single day. After a 10-day silence the stale EMA was
+       weighted as if it were yesterday's, and the effective time constant varied with
+       talkativeness -- itself mood-correlated, confounding the artifact with the outcome.
+       Now each update decays the previous EMA by (1 - alpha)**gap_days, the exact
+       continuous-time generalization of the daily EMA (gap of 1 day reproduces the old
+       step; longer gaps discount stale history accordingly).
+
+    2. Spike handling compared |value - lagging EMA| against a threshold derived from raw
+       consecutive deltas. During any genuine sustained shift the EMA lags, the deviation
+       grows, dampening latches on, and the EMA freezes against exactly the drift the
+       system exists to detect (depression onset). The dampener is replaced by a Hampel
+       filter applied to the raw series BEFORE smoothing: a point is an outlier only if it
+       deviates from its rolling-window MEDIAN by more than `hampel_k` robust standard
+       deviations (MAD * 1.4826). An isolated one-day artifact is clipped to the local
+       median; a sustained regime change moves the median itself within ~window/2 days and
+       passes through untouched. No feedback loop, no latch.
     """
 
-    def __init__(self, alpha=0.13, spike_multiplier=3.0, dampening_factor=0.3):
+    def __init__(self, alpha=0.13, hampel_window=5, hampel_k=3.0):
         self.alpha = alpha
-        self.spike_multiplier = spike_multiplier
-        self.dampening_factor = dampening_factor
+        self.hampel_window = hampel_window
+        self.hampel_k = hampel_k
 
-    def compute(self, values: List[float]) -> List[float]:
+    # ------------------------------------------------------------------ helpers
+    def _hampel(self, arr: np.ndarray) -> np.ndarray:
+        """Replace isolated outliers with their rolling-window median.
+
+        Centered window; at the edges the window shrinks to whatever is available.
+        A window whose MAD is 0 (locally constant data) falls back to the global MAD of
+        consecutive deltas; if that is also 0 the point is left untouched (a constant
+        series has no scale on which to call anything an outlier).
+        """
+        n = len(arr)
+        if n < 3:
+            return arr.copy()
+
+        half = self.hampel_window // 2
+        global_deltas = np.abs(np.diff(arr))
+        nonzero = global_deltas[global_deltas > 0]
+        global_scale = float(np.median(nonzero)) * MAD_TO_STD if nonzero.size else 0.0
+
+        out = arr.copy()
+        for i in range(n):
+            lo, hi = max(0, i - half), min(n, i + half + 1)
+            window = arr[lo:hi]
+            if len(window) < 3:
+                continue
+            med = float(np.median(window))
+            mad = float(np.median(np.abs(window - med)))
+            scale = mad * MAD_TO_STD if mad > 0 else global_scale
+            if scale > 0 and abs(arr[i] - med) > self.hampel_k * scale:
+                out[i] = med
+        return out
+
+    # ------------------------------------------------------------------ api
+    def compute(
+        self,
+        values: List[float],
+        timestamps: Optional[Sequence] = None,
+    ) -> List[float]:
+        """Smooth `values`. `timestamps` (datetime-like, same length, ascending) makes the
+        EMA time-aware; without it every step is assumed to be exactly one day (legacy
+        behavior, kept for callers that have no time axis)."""
         if not values:
             return []
 
         arr = np.asarray(values, dtype=float)
-        if len(arr) > 1:
-            deltas = np.abs(np.diff(arr))
-            nonzero = deltas[deltas > 0]
-            typical_step = float(np.median(nonzero)) if nonzero.size else 0.0
-        else:
-            typical_step = 0.0
-        # typical_step == 0 (constant series) => threshold 0 => never dampen.
-        spike_threshold = self.spike_multiplier * typical_step
+        filtered = self._hampel(arr)
 
-        ema = []
-        prev_ema = float(arr[0])
-        for val in arr:
-            delta = abs(val - prev_ema)
-            update = self.alpha * (val - prev_ema)
-            if spike_threshold > 0 and delta > spike_threshold:
-                update *= self.dampening_factor
-            prev_ema += update
-            ema.append(prev_ema)
+        if timestamps is not None:
+            ts = np.asarray(timestamps, dtype="datetime64[s]").astype("int64")
+            gaps_days = np.diff(ts) / 86400.0
+            # Guard against duplicate/non-monotonic timestamps: treat as a same-day
+            # correction (minimal decay) rather than a zero/negative gap.
+            gaps_days = np.clip(gaps_days, 1e-6, None)
+        else:
+            gaps_days = np.ones(len(arr) - 1)
+
+        ema = [float(filtered[0])]
+        prev = float(filtered[0])
+        for val, gap in zip(filtered[1:], gaps_days):
+            keep = (1.0 - self.alpha) ** gap  # weight left on the old EMA after `gap` days
+            prev = keep * prev + (1.0 - keep) * float(val)
+            ema.append(prev)
         return ema

--- a/temporal_context_modeling_layer/core/use_cases/AggregateMetricsUseCase.py
+++ b/temporal_context_modeling_layer/core/use_cases/AggregateMetricsUseCase.py
@@ -6,6 +6,9 @@ from core.models.AggregatedMetricRecord import AggregatedMetricRecord
 from datetime import timezone
 
 
+import os
+
+
 class AggregateMetricsUseCase:
     def __init__(self, repository: PersistencePort):
         self.repository = repository
@@ -20,17 +23,20 @@ class AggregateMetricsUseCase:
             if latest.tzinfo is None:
                 latest = latest.replace(tzinfo=timezone.utc)
 
-            # Re-process from the last aggregated DAY (inclusive), not the next day. Aggregation
-            # is day-bucketed and now idempotent (upsert), so revisiting the latest day picks up
-            # late-arriving same-day utterances; `+1 day` would silently drop them.
-            start_date = latest
+            # Re-process from a LOOKBACK window before the last aggregated day, not just the
+            # last day itself. Edge nodes buffer and backfill after connectivity gaps, so raw
+            # records routinely arrive for days that already passed the watermark; reading
+            # only `>= latest` would leave those earlier days' aggregates permanently wrong.
+            # Upserts are idempotent, so re-aggregating the window is safe and cheap.
+            backfill_days = int(os.getenv("TEMPORAL_BACKFILL_DAYS", "3"))
+            start_date = latest - timedelta(days=backfill_days)
 
         metrics = self.repository.get_raw_metrics(
             user_id=user_id, start_date=start_date
         )
 
         if not metrics:
-            return {}
+            return []
 
         aggregated_metrics = aggregate_metrics(metrics)
 

--- a/temporal_context_modeling_layer/core/use_cases/ComputeContextualMetricsUseCase.py
+++ b/temporal_context_modeling_layer/core/use_cases/ComputeContextualMetricsUseCase.py
@@ -1,6 +1,7 @@
 from ports.PersistencePort import PersistencePort
 from core.services.temporal_context.SpikeDampenedEMA import SpikeDampenedEMA
 from core.services.temporal_context.HMM import HMM
+import os
 import pandas as pd
 from datetime import timedelta, datetime
 from typing import List
@@ -15,21 +16,10 @@ class ComputeContextualMetricsUseCase:
         self, user_id: str, method: str = "ema"
     ) -> List[ContextualMetricRecord]:
 
-        latest = self.repository.get_latest_contextual_metric_date(user_id)
-        start_date = None
-        if latest:
-            if isinstance(latest, str):
-                latest = datetime.fromisoformat(latest)
-            start_date = pd.Timestamp(latest)
-            # Normalize to naive UTC so the watermark can't mix tz-aware/naive datetimes.
-            if start_date.tzinfo is not None:
-                start_date = start_date.tz_convert("UTC").tz_localize(None)
-            start_date = start_date + pd.Timedelta(days=1)
-
         # NOTE: the full aggregated history is read intentionally -- the EMA is stateful and
-        # needs all prior values for correct smoothing continuity. Reading only the window
-        # past start_date would cold-restart the EMA and change results; the right perf fix
-        # is to persist the EMA state, not to window the read.
+        # needs all prior values for correct smoothing continuity. Reading only a recent
+        # window would cold-restart the EMA and change results; the right perf fix is to
+        # persist the EMA state, not to window the read.
         metrics = self.repository.get_aggregated_metrics(user_id)
         if not metrics:
             return []
@@ -53,6 +43,18 @@ class ComputeContextualMetricsUseCase:
         if "system_mode" not in df.columns:
             df["system_mode"] = "live"
 
+        # Minimum-evidence gate: a daily mean built from fewer than MIN_N utterances is
+        # noise, not a day-level observation, and would enter the EMA with the same weight
+        # as a 300-utterance day (pseudoreplication). Gated days are treated as gaps --
+        # the time-aware EMA discounts across them correctly. Legacy records without a
+        # sample_count pass the gate (their evidence is unknown, not absent).
+        min_n = int(os.getenv("TEMPORAL_MIN_DAILY_SAMPLES", "1"))
+        if min_n > 1 and "sample_count" in df.columns:
+            counted = df["sample_count"].notna()
+            df = df[~counted | (df["sample_count"] >= min_n)]
+            if df.empty:
+                return []
+
         model = SpikeDampenedEMA() if method == "ema" else HMM()
 
         contextual_records = []
@@ -71,25 +73,30 @@ class ComputeContextualMetricsUseCase:
             for metric in daily.columns:
                 # Use only ACTUAL observations. The previous ffill().bfill() invented values
                 # across day gaps, which the EMA/HMM then treated as real data, biasing the
-                # baseline during absence periods.
+                # baseline during absence periods. The model receives the observation
+                # timestamps so it can weight updates by the REAL elapsed time across gaps.
                 values = daily[metric].dropna()
                 if values.empty:
                     continue
-                baseline = model.compute(values.tolist())
+                baseline = model.compute(values.tolist(), timestamps=values.index)
                 dev = abs(values - baseline)
 
+                # Upsert the FULL recomputed history, not just days past a watermark:
+                # backfilled raw data can correct an old aggregated day, which shifts every
+                # later EMA value; writing only "new" days would leave stale contextual
+                # values for the corrected span. Upserts are idempotent, so rewriting
+                # unchanged days is a no-op.
                 for timestamp, dev_val, base_val in zip(values.index, dev, baseline):
-                    if start_date is None or timestamp >= start_date:
-                        contextual_records.append(
-                            ContextualMetricRecord(
-                                user_id=resolved_user_id,
-                                timestamp=timestamp,
-                                metric_name=metric,
-                                contextual_value=float(base_val),
-                                metric_dev=float(dev_val),
-                                system_mode=system_mode,
-                            )
+                    contextual_records.append(
+                        ContextualMetricRecord(
+                            user_id=resolved_user_id,
+                            timestamp=timestamp,
+                            metric_name=metric,
+                            contextual_value=float(base_val),
+                            metric_dev=float(dev_val),
+                            system_mode=system_mode,
                         )
+                    )
 
         self.repository.save_contextual_metrics(contextual_records)
 

--- a/temporal_context_modeling_layer/tests/test_aggregation_and_ema.py
+++ b/temporal_context_modeling_layer/tests/test_aggregation_and_ema.py
@@ -1,7 +1,7 @@
-"""Tests for the day-bucketing aggregation and the variability-based EMA spike dampening."""
+"""Tests for local-day aggregation (with n/std bookkeeping) and the robust time-aware EMA."""
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -16,6 +16,7 @@ def R(uid, ts, name, val, mode="dataset"):
     )
 
 
+# --------------------------------------------------------------------------- aggregation
 def test_day_bucketing_collapses_same_day():
     recs = [
         R(1, datetime(2026, 1, 1, 9, 0), "f0", 100),
@@ -41,6 +42,41 @@ def test_modes_kept_separate():
     assert {a.system_mode for a in out} == {"dataset", "demo"}
 
 
+def test_local_timezone_bucketing():
+    # 23:30 UTC on Jan 1 is 00:30 Jan 2 in Zurich (UTC+1 in winter): with TEMPORAL_TZ it
+    # must land in the Jan 2 LOCAL day, not split the user's evening across two days.
+    recs = [
+        R(1, datetime(2026, 1, 1, 23, 30), "f0", 100),
+        R(1, datetime(2026, 1, 2, 8, 0), "f0", 200),  # 09:00 local, same local day
+    ]
+    out = aggregate_metrics(recs, tz="Europe/Zurich")
+    assert len(out) == 1, "both records fall on the same LOCAL day"
+    assert out[0].timestamp.date() == datetime(2026, 1, 2).date()
+    assert out[0].aggregated_value == 150
+    # default (UTC) keeps historical behavior: two separate days
+    assert len(aggregate_metrics(recs)) == 2
+
+
+def test_sample_count_and_std_recorded():
+    recs = [
+        R(1, datetime(2026, 1, 1, 9), "f0", 100),
+        R(1, datetime(2026, 1, 1, 12), "f0", 110),
+        R(1, datetime(2026, 1, 1, 18), "f0", 120),
+        R(1, datetime(2026, 1, 2, 9), "f0", 300),  # single-sample day
+    ]
+    out = {a.timestamp.date(): a for a in aggregate_metrics(recs)}
+    d1 = out[datetime(2026, 1, 1).date()]
+    d2 = out[datetime(2026, 1, 2).date()]
+    assert d1.sample_count == 3
+    assert d1.sample_std is not None and d1.sample_std > 0
+    assert d2.sample_count == 1
+    assert d2.sample_std is None, "n=1 has no dispersion information"
+    # to_dict carries the evidence fields for persistence
+    d = d1.to_dict()
+    assert d["sample_count"] == 3 and d["sample_std"] == d1.sample_std
+
+
+# --------------------------------------------------------------------------- EMA
 def test_ema_constant_series_unchanged():
     ema = SpikeDampenedEMA().compute([5.0] * 10)
     assert all(abs(v - 5.0) < 1e-9 for v in ema)
@@ -52,11 +88,56 @@ def test_ema_zero_centered_not_overdamped():
     assert len(ema) == 5
 
 
-def test_ema_dampens_genuine_spike():
-    # Realistic baseline: small natural day-to-day noise, then one large outlier.
+def test_ema_clips_isolated_spike():
+    # Realistic baseline: small natural day-to-day noise, one isolated large outlier.
     base = [10.0, 10.2, 9.8, 10.1, 9.9, 10.3, 9.7, 10.0, 10.1, 9.9]
     series = base + [1000.0] + [10.0, 10.2, 9.8, 10.1, 9.9]
     ema = SpikeDampenedEMA().compute(series)
     jump = ema[10] - ema[9]
     undamped = 0.13 * (1000.0 - ema[9])
-    assert jump < undamped * 0.5, "the large outlier step should be dampened vs the noisy baseline"
+    assert jump < undamped * 0.05, "isolated outlier should be clipped by the Hampel filter"
+
+
+def test_ema_follows_sustained_shift():
+    # THE C2 regression test: a genuine sustained regime change (depression onset) must
+    # NOT be dampened. After the shift persists past the Hampel window, the EMA must
+    # converge on the new level at full (undampened) speed.
+    alpha = 0.13
+    series = [10.0] * 10 + [20.0] * 15
+    ema = SpikeDampenedEMA(alpha=alpha).compute(series)
+    # Reference: plain EMA on the same (unfiltered) series.
+    ref = [10.0]
+    for v in series[1:]:
+        ref.append((1 - alpha) * ref[-1] + alpha * v)
+    # By the end of the sustained shift the robust EMA must be at least as converged as
+    # the plain EMA is a few steps earlier -- i.e. no latch, only a bounded startup delay
+    # while the shift is inside the Hampel window.
+    assert ema[-1] > ref[-4], f"sustained shift was suppressed: {ema[-1]:.2f} vs plain {ref[-1]:.2f}"
+    assert abs(ema[-1] - 20.0) < abs(ema[9] - 20.0) * 0.35, "EMA must converge toward the new level"
+
+
+def test_ema_time_aware_gap_discounting():
+    # Observations on days 0,1,2 then silence until day 13: the day-13 update must
+    # discount the 11-day-old EMA by (1-alpha)**11, NOT treat it as yesterday's value.
+    alpha = 0.13
+    t0 = datetime(2026, 1, 1)
+    ts = [t0, t0 + timedelta(days=1), t0 + timedelta(days=2), t0 + timedelta(days=13)]
+    vals = [10.0, 10.0, 10.0, 20.0]
+    ema = SpikeDampenedEMA(alpha=alpha).compute(vals, timestamps=ts)
+    keep = (1 - alpha) ** 11
+    expected = keep * 10.0 + (1 - keep) * 20.0
+    assert abs(ema[-1] - expected) < 1e-6, f"got {ema[-1]}, expected {expected}"
+    # and the index-spaced (no timestamps) result would be much closer to the old value
+    ema_legacy = SpikeDampenedEMA(alpha=alpha).compute(vals)
+    assert ema[-1] > ema_legacy[-1] + 1.0, "time-aware EMA must discount stale history more"
+
+
+def test_ema_equal_spacing_matches_legacy_step():
+    # With one observation per day, the time-aware EMA reduces exactly to the daily EMA.
+    alpha = 0.13
+    t0 = datetime(2026, 1, 1)
+    ts = [t0 + timedelta(days=i) for i in range(6)]
+    vals = [10.0, 12.0, 11.0, 13.0, 12.5, 12.0]
+    with_ts = SpikeDampenedEMA(alpha=alpha).compute(vals, timestamps=ts)
+    without_ts = SpikeDampenedEMA(alpha=alpha).compute(vals)
+    assert all(abs(a - b) < 1e-9 for a, b in zip(with_ts, without_ts))

--- a/temporal_context_modeling_layer/tests/test_use_case_watermarks.py
+++ b/temporal_context_modeling_layer/tests/test_use_case_watermarks.py
@@ -1,0 +1,132 @@
+"""Use-case-level tests: backfill lookback on aggregation, full-history contextual rewrite,
+and the minimum-evidence gate. Uses an in-memory fake repository (no Mongo)."""
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.models.RawMetricRecord import RawMetricRecord
+from core.use_cases.AggregateMetricsUseCase import AggregateMetricsUseCase
+from core.use_cases.ComputeContextualMetricsUseCase import ComputeContextualMetricsUseCase
+
+
+class FakeRepo:
+    def __init__(self):
+        self.raw = []
+        self.aggregated = []          # list of AggregatedMetricRecord
+        self.contextual_saved = []    # accumulate every save call
+        self.raw_query_start = "UNSET"
+
+    # aggregation side
+    def get_latest_aggregated_metric_date(self, user_id):
+        return max((a.timestamp for a in self.aggregated), default=None)
+
+    def get_raw_metrics(self, user_id, start_date=None):
+        self.raw_query_start = start_date
+        if start_date is None:
+            return list(self.raw)
+        sd = start_date.replace(tzinfo=None) if start_date.tzinfo else start_date
+        return [r for r in self.raw if r.timestamp >= sd]
+
+    def save_aggregated_metrics(self, records):
+        self.aggregated.extend(records)
+
+    # contextual side
+    def get_latest_contextual_metric_date(self, user_id):
+        return None
+
+    def get_aggregated_metrics(self, user_id, start_date=None):
+        return [
+            {
+                "user_id": a["user_id"], "timestamp": a["timestamp"],
+                "metric_name": a["metric_name"], "aggregated_value": a["aggregated_value"],
+                "system_mode": a.get("system_mode", "live"),
+                "sample_count": a.get("sample_count"), "sample_std": a.get("sample_std"),
+            }
+            for a in self.agg_dicts
+        ]
+
+    def save_contextual_metrics(self, records):
+        self.contextual_saved = records
+
+
+def R(day, hour, val):
+    return RawMetricRecord(
+        user_id=1, timestamp=datetime(2026, 1, day, hour), metric_name="f0",
+        metric_value=val, system_mode="live",
+    )
+
+
+def A(day, val, n=5):
+    return {
+        "user_id": 1, "timestamp": datetime(2026, 1, day), "metric_name": "f0",
+        "aggregated_value": val, "system_mode": "live", "sample_count": n, "sample_std": 1.0,
+    }
+
+
+def test_aggregation_backfill_lookback():
+    repo = FakeRepo()
+    repo.raw = [R(d, 9, 100 + d) for d in range(1, 11)]
+    uc = AggregateMetricsUseCase(repo)
+
+    # first run: no watermark, everything read
+    uc.aggregate_metrics(1)
+    assert repo.raw_query_start is None
+    assert len(repo.aggregated) == 10
+
+    # second run: watermark = Jan 10 -> must re-read from Jan 10 - TEMPORAL_BACKFILL_DAYS
+    os.environ["TEMPORAL_BACKFILL_DAYS"] = "3"
+    try:
+        uc.aggregate_metrics(1)
+    finally:
+        del os.environ["TEMPORAL_BACKFILL_DAYS"]
+    assert repo.raw_query_start is not None
+    start = repo.raw_query_start.replace(tzinfo=None)
+    assert start == datetime(2026, 1, 7), f"lookback should reach 3 days back, got {start}"
+
+
+def test_aggregation_empty_returns_list():
+    repo = FakeRepo()
+    out = AggregateMetricsUseCase(repo).aggregate_metrics(1)
+    assert out == [], "empty result must be a list, not a dict"
+
+
+def test_contextual_rewrites_full_history():
+    repo = FakeRepo()
+    repo.agg_dicts = [A(d, 10.0 + d) for d in range(1, 8)]
+    uc = ComputeContextualMetricsUseCase(repo)
+    records = uc.compute(1)
+    # all 7 days rewritten (idempotent upserts), not just days past a watermark
+    assert len(records) == 7
+    assert len({r.timestamp for r in records}) == 7
+
+
+def test_contextual_min_n_gate():
+    repo = FakeRepo()
+    repo.agg_dicts = [
+        A(1, 10.0, n=5), A(2, 10.5, n=1), A(3, 11.0, n=5),  # day 2 has 1 utterance
+    ]
+    uc = ComputeContextualMetricsUseCase(repo)
+
+    os.environ["TEMPORAL_MIN_DAILY_SAMPLES"] = "3"
+    try:
+        records = uc.compute(1)
+    finally:
+        del os.environ["TEMPORAL_MIN_DAILY_SAMPLES"]
+    days = {r.timestamp.day for r in records}
+    assert days == {1, 3}, "the 1-utterance day must be gated out (treated as a gap)"
+
+    # legacy records without sample_count must pass the gate
+    repo2 = FakeRepo()
+    legacy = [A(1, 10.0), A(2, 10.5), A(3, 11.0)]
+    for a in legacy:
+        a["sample_count"] = None
+        a["sample_std"] = None
+    repo2.agg_dicts = legacy
+    os.environ["TEMPORAL_MIN_DAILY_SAMPLES"] = "3"
+    try:
+        records2 = ComputeContextualMetricsUseCase(repo2).compute(1)
+    finally:
+        del os.environ["TEMPORAL_MIN_DAILY_SAMPLES"]
+    assert len(records2) == 3, "legacy records (unknown evidence) must not be gated"


### PR DESCRIPTION
Round-3 review fixes for the temporal layer (2 CRITICAL, 4 MAJOR, minors):

- **C1** EMA smoothed over observation index, not calendar time → time-aware EMA, decay `(1-alpha)**gap_days`; silence gaps no longer masquerade as consecutive days and the effective time constant stops varying with talkativeness (a mood-correlated confound).
- **C2** spike dampener latched onto sustained regime changes (the depression signal) → replaced with a Hampel filter (rolling median ± k·MAD): isolated outliers clipped, sustained shifts pass through. Regression test included.
- **M1** UTC day-bucketing smeared local diurnal structure → `TEMPORAL_TZ` env (default UTC = legacy behavior; set `Europe/Zurich` in compose for live).
- **M2** late/backfilled raw data before the watermark was silently dropped → `TEMPORAL_BACKFILL_DAYS` lookback (default 3).
- **M3** daily means carried no n/variance (pseudoreplication) → `sample_count` + `sample_std` persisted; `TEMPORAL_MIN_DAILY_SAMPLES` gate treats under-evidenced days as gaps (legacy records pass).
- **M4** HMM contextualizer documented + runtime-warned as non-reproducible on growing histories.
- **m3** contextual now rewrites full recomputed history (idempotent upserts) so corrected old days propagate; **m4** empty aggregation returns `[]` not `{}`.

**Validation:** 19/19 tests pass on the VM (incl. new: sustained-shift pass-through, gap discounting, tz bucketing, n/std bookkeeping, backfill lookback, min-n gate).

⚠️ Deploy note: set `TEMPORAL_TZ=Europe/Zurich` and `TEMPORAL_MIN_DAILY_SAMPLES=3` in compose for the 30-day live deployment. Must be merged BEFORE the deployment starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)