### PR TITLE
feat(firmware): plug-and-play P1 — captive portal, mDNS discovery, MQTT segment offload

### DIFF
--- a/data_ingestion_layer/firmware/main/CMakeLists.txt
+++ b/data_ingestion_layer/firmware/main/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SRCS
     "net/mqtt_client.c"
     "protocol/node_protocol.c"
     "features/edge_features.c"
+    "transport/mqtt_sender.c"
 )
 
 # Add XVF3800 driver for that board variant
@@ -43,6 +44,7 @@ set(INCLUDE_DIRS
     "net"
     "protocol"
     "features"
+    "transport"
 )
 
 # Register component with ESP-IDF build system
@@ -61,9 +63,11 @@ idf_component_register(
         esp_system
         # Plug-and-play edge-offload deps:
         mqtt                 # esp-mqtt (broker transport)
-        mdns                 # sink discovery (_iotsensing-mqtt._tcp)
-        wifi_provisioning    # SoftAP/BLE first-boot Wi-Fi setup
+        mdns                 # sink discovery (_iotsensing-mqtt._tcp); managed component
+                             # -> main/idf_component.yml pins espressif/mdns
+        esp_http_server      # provisioning captive portal
         json                 # cJSON (protocol payloads)
+        mbedtls              # base64 for segment payloads
         # esp-dsp is a managed component: add espressif/esp-dsp to idf_component.yml for
         # on-node feature extraction (features/edge_features.c).
 )

--- a/data_ingestion_layer/firmware/main/Kconfig.projbuild
+++ b/data_ingestion_layer/firmware/main/Kconfig.projbuild
@@ -21,6 +21,63 @@ menu "IHearYou Firmware Configuration"
                 I2S Mode: Slave (XVF3800 is master)
     endchoice
 
+    choice TRANSPORT_MODE
+        prompt "Transport"
+        default TRANSPORT_MQTT_OFFLOAD
+        help
+            How captured speech leaves the node.
+
+        config TRANSPORT_MQTT_OFFLOAD
+            bool "Plug-and-play MQTT offload (mDNS discovery + capability negotiation)"
+            help
+                The plug-and-play path: provision once (or ride the default site SSID),
+                mDNS-discover the broker, advertise capabilities, receive an assignment,
+                publish VAD-gated segments (or features) over authenticated MQTT.
+
+        config TRANSPORT_LEGACY_TCP
+            bool "Legacy raw TCP to respeaker_service (compiled server IP)"
+            help
+                The original pipeline: stream VAD-gated PCM to SERVER_HOST:SERVER_PORT.
+    endchoice
+
+    menu "Plug-and-play Provisioning"
+        depends on TRANSPORT_MQTT_OFFLOAD
+
+        config DEFAULT_SITE_SSID
+            string "Default site SSID (zero-config)"
+            default "IHearYou-Net"
+            help
+                Factory-fresh nodes try this network BEFORE opening the setup portal.
+                Broadcast it from the site's central node (clinic AP) and boards need no
+                per-device configuration at all: power on -> join -> discover -> pending
+                approval in the dashboard.
+
+        config DEFAULT_SITE_PASS
+            string "Default site password"
+            default "ihearyou-setup"
+
+        config BOOTSTRAP_MQTT_USER
+            string "Bootstrap MQTT username"
+            default "node-bootstrap"
+            help
+                Low-privilege enrollment account: ACL-limited to nodes/{id}/capabilities,
+                nodes/{id}/status (pub) and nodes/{id}/config, nodes/{id}/provision (sub).
+                Per-node credentials are minted at dashboard approval (EDGE_TRUST_MODEL.md).
+
+        config BOOTSTRAP_MQTT_PASS
+            string "Bootstrap MQTT password"
+            default ""
+
+        config EDGE_FEATURE_SNR
+            bool "Advertise on-node SNR"
+            default y
+
+        config EDGE_FEATURE_SPECTRAL_FLATNESS
+            bool "Advertise on-node spectral flatness"
+            default y
+
+    endmenu
+
     menu "Network Configuration"
 
         config WIFI_SSID

--- a/data_ingestion_layer/firmware/main/app/offload_app.c
+++ b/data_ingestion_layer/firmware/main/app/offload_app.c
@@ -1,17 +1,51 @@
-// offload_app.c — plug-and-play boot state machine (skeleton).
-// See docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md. Wires provisioning -> discovery ->
-// mqtt -> negotiate -> stream, and applies live config. Hardware/SDK-gated steps marked TODO.
+// offload_app.c — plug-and-play boot state machine.
+// See docs/firmware/PLUG_AND_PLAY_OFFLOAD_DESIGN.md. Wires provisioning -> wifi ->
+// discovery -> mqtt -> negotiate -> stream, and applies live config.
+//
+// Zero-config chain (the clinic scenario): a factory-fresh node first tries the DEFAULT
+// SITE network (CONFIG_DEFAULT_SITE_SSID — the SSID the central node's AP broadcasts, or
+// a site-standard IoT SSID). If that network exists, the node needs NO per-device setup
+// at all: power it on, it joins, mDNS-finds the sink, advertises itself, and shows up in
+// the dashboard's Edge Nodes -> Pending list for one-click approval. Only when no default
+// network is reachable does it fall back to the SoftAP captive portal.
 #include "app/offload_app.h"
 #include "net/discovery.h"
 #include "net/mqtt_client.h"
-#include "wifi_manager.h"        // existing
+#include "transport/mqtt_sender.h"
+#include "wifi_manager.h"        // existing STA manager
 #include "board_config.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
+#include "esp_wifi.h"
+#include "esp_timer.h"
+#include "esp_system.h"
 #include <string.h>
+#include <stdio.h>
 
 static const char *TAG = "offload_app";
+
+#ifndef CONFIG_DEFAULT_SITE_SSID
+#define CONFIG_DEFAULT_SITE_SSID "IHearYou-Net"
+#endif
+#ifndef CONFIG_DEFAULT_SITE_PASS
+#define CONFIG_DEFAULT_SITE_PASS "ihearyou-setup"
+#endif
+// Low-privilege bootstrap MQTT account: may ONLY publish nodes/{id}/capabilities|status
+// and subscribe nodes/{id}/config|provision (broker ACL). Per-node credentials are minted
+// by the server at dashboard approval and pushed on nodes/{id}/provision (retained); the
+// node persists them and reconnects with its own identity. See EDGE_TRUST_MODEL.md.
+#ifndef CONFIG_BOOTSTRAP_MQTT_USER
+#define CONFIG_BOOTSTRAP_MQTT_USER "node-bootstrap"
+#endif
+#ifndef CONFIG_BOOTSTRAP_MQTT_PASS
+#define CONFIG_BOOTSTRAP_MQTT_PASS ""
+#endif
+
+#define WIFI_TRY_DEFAULT_TIMEOUT_MS 15000
+#define STATUS_DEFAULT_INTERVAL_MS  30000
+
+static bool s_sender_started;
 
 void offload_app_build_capabilities(app_ctx_t *ctx) {
     np_capabilities_t *c = &ctx->caps;
@@ -39,6 +73,7 @@ void offload_app_build_capabilities(app_ctx_t *ctx) {
     c->provides.features[i] = NULL;
 }
 
+// --------------------------------------------------------------------------- mqtt in
 void offload_app_on_mqtt(const char *topic, const char *data, size_t len, void *user) {
     app_ctx_t *ctx = (app_ctx_t *)user;
     char cfg_topic[64];
@@ -51,28 +86,65 @@ void offload_app_on_mqtt(const char *topic, const char *data, size_t len, void *
                      ctx->assignment.vad_gated);
         }
     }
+    // TODO(P2, per-node creds): handle nodes/{id}/provision here -- parse the minted
+    // mqtt_user/mqtt_pass, provisioning_save(), mqtt_client_stop(), state = APP_RECONNECT
+    // so the node comes back under its own ACL'd identity.
 }
 
+// --------------------------------------------------------------------------- wifi
+static bool wifi_join(const char *ssid, const char *pass, int timeout_ms) {
+    wifi_manager_config_t wc = {0};
+    strncpy(wc.ssid, ssid, sizeof(wc.ssid) - 1);
+    strncpy(wc.password, pass, sizeof(wc.password) - 1);
+    wc.max_retry_count = 3;
+    wc.retry_interval_ms = 2000;
+    if (wifi_manager_init(&wc) != ESP_OK || wifi_manager_start() != ESP_OK) return false;
+    for (int waited = 0; waited < timeout_ms; waited += 250) {
+        if (wifi_manager_is_connected()) return true;
+        vTaskDelay(pdMS_TO_TICKS(250));
+    }
+    wifi_manager_stop();
+    return false;
+}
+
+// --------------------------------------------------------------------------- connect
 static bool connect_and_negotiate(app_ctx_t *ctx) {
     // DISCOVER_SINK: mDNS -> NVS broker -> Kconfig host.
     discovery_result_t sink;
     if (!discovery_find_sink(5000, ctx->prov.broker_host, ctx->prov.broker_port, &sink)) {
-        ESP_LOGW(TAG, "no broker found"); return false;
+        ESP_LOGW(TAG, "no broker found");
+        return false;
     }
     ESP_LOGI(TAG, "sink %s:%d (mdns=%d)", sink.host, sink.port, sink.from_mdns);
-    // Remember the broker for faster next boot (TODO: provisioning_save with updated host).
 
-    // MQTT_CONN
+    // MQTT_CONN — per-node creds from NVS when provisioned, else the bootstrap account.
     mqtt_client_cfg_t mc = {0};
-    strncpy(mc.host, sink.host, sizeof(mc.host));
+    strncpy(mc.host, sink.host, sizeof(mc.host) - 1);
     mc.port = sink.port; mc.tls = sink.tls;
-    strncpy(mc.client_id, ctx->node_id, sizeof(mc.client_id));
-    strncpy(mc.username, ctx->prov.mqtt_user, sizeof(mc.username));
-    strncpy(mc.password, ctx->prov.mqtt_pass, sizeof(mc.password));
+    strncpy(mc.client_id, ctx->node_id, sizeof(mc.client_id) - 1);
+    if (ctx->prov.mqtt_user[0]) {
+        strncpy(mc.username, ctx->prov.mqtt_user, sizeof(mc.username) - 1);
+        strncpy(mc.password, ctx->prov.mqtt_pass, sizeof(mc.password) - 1);
+    } else {
+        strncpy(mc.username, CONFIG_BOOTSTRAP_MQTT_USER, sizeof(mc.username) - 1);
+        strncpy(mc.password, CONFIG_BOOTSTRAP_MQTT_PASS, sizeof(mc.password) - 1);
+    }
+    // LWT: broker marks us offline (retained) if we die uncleanly.
+    np_topic_status(ctx->node_id, mc.lwt_topic, sizeof(mc.lwt_topic));
+    snprintf(mc.lwt_payload, sizeof(mc.lwt_payload), "{\"node_id\":\"%s\",\"online\":false}",
+             ctx->node_id);
     mc.on_message = offload_app_on_mqtt; mc.user = ctx;
     if (!mqtt_client_start(&mc)) return false;
     for (int i = 0; i < 50 && !mqtt_client_is_connected(); i++) vTaskDelay(pdMS_TO_TICKS(100));
-    if (!mqtt_client_is_connected()) return false;
+    if (!mqtt_client_is_connected()) { mqtt_client_stop(); return false; }
+
+    // Remember the broker so the next boot skips straight past an empty mDNS window.
+    if (sink.from_mdns && (strcmp(ctx->prov.broker_host, sink.host) != 0 ||
+                           ctx->prov.broker_port != sink.port)) {
+        strncpy(ctx->prov.broker_host, sink.host, sizeof(ctx->prov.broker_host) - 1);
+        ctx->prov.broker_port = sink.port;
+        provisioning_save(&ctx->prov);
+    }
 
     // NEGOTIATE: subscribe config, publish capabilities (retained), wait for assignment.
     char t_cfg[64], t_cap[64];
@@ -80,44 +152,96 @@ static bool connect_and_negotiate(app_ctx_t *ctx) {
     np_topic_capabilities(ctx->node_id, t_cap, sizeof(t_cap));
     mqtt_client_subscribe(t_cfg, 1);
     char *adv = np_build_capabilities_json(&ctx->caps);
+    if (!adv) return false;
     mqtt_client_publish(t_cap, adv, strlen(adv), 1, /*retain=*/true);
     free(adv);
     for (int i = 0; i < 100 && !ctx->assignment.valid; i++) vTaskDelay(pdMS_TO_TICKS(100));
-    return ctx->assignment.valid;  // server replied with a config
+    if (!ctx->assignment.valid) {
+        // No registry answer yet: the node is likely UNAPPROVED. Stay connected and keep
+        // waiting -- the retained capabilities advert sits in the broker, the dashboard
+        // shows the node under Pending, and approval pushes the config at any time.
+        ESP_LOGW(TAG, "no assignment yet; waiting for dashboard approval");
+    }
+    return true;  // connected; streaming starts once an assignment arrives
 }
 
+// --------------------------------------------------------------------------- status
+static void publish_status(app_ctx_t *ctx) {
+    char topic[64];
+    np_topic_status(ctx->node_id, topic, sizeof(topic));
+    char *json = np_build_status_json(
+        ctx->node_id, ctx->assignment.valid ? ctx->assignment.mode : NP_MODE_SEGMENTS,
+        wifi_manager_get_rssi(), (uint32_t)(esp_timer_get_time() / 1000000ULL),
+        esp_get_free_heap_size(), ctx->latest_doa);
+    if (json) {
+        mqtt_client_publish(topic, json, strlen(json), 1, /*retain=*/true);
+        free(json);
+    }
+}
+
+// --------------------------------------------------------------------------- task
 static void app_task(void *arg) {
     app_ctx_t *ctx = (app_ctx_t *)arg;
+    int64_t last_status_ms = 0;
     for (;;) {
+        provisioning_check_factory_reset();  // BOOT held >=5 s -> wipe + portal
         switch (ctx->state) {
         case APP_BOOT:
-            if (!provisioning_load(&ctx->prov)) { ctx->state = APP_PROVISIONING; break; }
-            ctx->state = APP_WIFI_CONNECT; break;
+            if (provisioning_load(&ctx->prov)) { ctx->state = APP_WIFI_CONNECT; break; }
+            // Factory-fresh: try the zero-config site network before bothering a human.
+            ESP_LOGI(TAG, "unprovisioned; trying default site SSID '%s'", CONFIG_DEFAULT_SITE_SSID);
+            if (wifi_join(CONFIG_DEFAULT_SITE_SSID, CONFIG_DEFAULT_SITE_PASS,
+                          WIFI_TRY_DEFAULT_TIMEOUT_MS)) {
+                strncpy(ctx->prov.wifi_ssid, CONFIG_DEFAULT_SITE_SSID, sizeof(ctx->prov.wifi_ssid) - 1);
+                strncpy(ctx->prov.wifi_pass, CONFIG_DEFAULT_SITE_PASS, sizeof(ctx->prov.wifi_pass) - 1);
+                strcpy(ctx->prov.environment, "unassigned");
+                provisioning_save(&ctx->prov);
+                ctx->state = APP_DISCOVER_SINK;
+                break;
+            }
+            ctx->state = APP_PROVISIONING;
+            break;
         case APP_PROVISIONING:
             ESP_LOGI(TAG, "entering provisioning portal");
-            provisioning_run_portal(&ctx->prov, /*timeout_s=*/0);  // blocks until creds
-            ctx->state = APP_WIFI_CONNECT; break;
+            provisioning_run_portal(&ctx->prov, /*timeout_s=*/0);  // restarts on success
+            break;
         case APP_WIFI_CONNECT:
-            // wifi_manager already STA-connects from creds; here ensure creds applied + wait IP.
-            // TODO: wifi_manager_set_credentials(ctx->prov.wifi_ssid, ctx->prov.wifi_pass)
-            if (wifi_manager_is_connected()) ctx->state = APP_DISCOVER_SINK;
-            else vTaskDelay(pdMS_TO_TICKS(500));
+            if (wifi_manager_is_connected()) { ctx->state = APP_DISCOVER_SINK; break; }
+            if (wifi_join(ctx->prov.wifi_ssid, ctx->prov.wifi_pass, 20000)) {
+                ctx->state = APP_DISCOVER_SINK;
+            } else {
+                ESP_LOGW(TAG, "cannot join '%s'; retrying", ctx->prov.wifi_ssid);
+                vTaskDelay(pdMS_TO_TICKS(5000));
+            }
             break;
         case APP_DISCOVER_SINK:  // DISCOVER_SINK + MQTT_CONN + NEGOTIATE
             ctx->state = connect_and_negotiate(ctx) ? APP_STREAMING : APP_RECONNECT;
             break;
-        case APP_STREAMING:
-            // Audio pipeline runs in i2s/vad tasks; the transport router reads ctx->assignment.
+        case APP_STREAMING: {
             if (!mqtt_client_is_connected()) { ctx->state = APP_RECONNECT; break; }
-            if (ctx->config_dirty) { ctx->config_dirty = false; /* re-apply mode live */ }
-            vTaskDelay(pdMS_TO_TICKS(500));
+            if (!s_sender_started && ctx->assignment.valid) {
+                s_sender_started = true;
+                mqtt_sender_start(ctx);   // audio pipeline (i2s/vad) is already running
+            }
+            if (ctx->config_dirty) { ctx->config_dirty = false; /* mode read live by sender */ }
+            int64_t now_ms = esp_timer_get_time() / 1000;
+            int interval = ctx->assignment.valid && ctx->assignment.report_interval_ms > 0
+                               ? ctx->assignment.report_interval_ms : STATUS_DEFAULT_INTERVAL_MS;
+            if (now_ms - last_status_ms >= interval) {
+                last_status_ms = now_ms;
+                publish_status(ctx);
+            }
+            vTaskDelay(pdMS_TO_TICKS(100));
             break;
+        }
         case APP_RECONNECT:
-            ESP_LOGW(TAG, "reconnecting"); mqtt_client_stop();
+            ESP_LOGW(TAG, "reconnecting");
+            mqtt_client_stop();
             vTaskDelay(pdMS_TO_TICKS(2000));
             ctx->state = wifi_manager_is_connected() ? APP_DISCOVER_SINK : APP_WIFI_CONNECT;
             break;
-        default: vTaskDelay(pdMS_TO_TICKS(200));
+        default:
+            vTaskDelay(pdMS_TO_TICKS(200));
         }
     }
 }

--- a/data_ingestion_layer/firmware/main/idf_component.yml
+++ b/data_ingestion_layer/firmware/main/idf_component.yml
@@ -1,0 +1,5 @@
+# Managed components (resolved by the IDF Component Manager at build time).
+dependencies:
+  idf: ">=5.1"
+  espressif/mdns: "^1.4.0"        # sink discovery (_iotsensing-mqtt._tcp)
+  # espressif/esp-dsp: "^1.5.0"   # enable when edge_features FFT paths are validated

--- a/data_ingestion_layer/firmware/main/main.c
+++ b/data_ingestion_layer/firmware/main/main.c
@@ -35,6 +35,12 @@
 #include "drivers/xvf3800/xvf3800.h"
 #endif
 
+#if CONFIG_TRANSPORT_MQTT_OFFLOAD
+#include "app/offload_app.h"
+// Plug-and-play runtime state (provisioning, capabilities, live assignment).
+static app_ctx_t s_app_ctx;
+#endif
+
 static const char *TAG = "IHEARYOU";
 
 // =============================================================================
@@ -55,7 +61,9 @@ static EventGroupHandle_t s_app_event_group;
 
 static TaskHandle_t s_i2s_capture_task = NULL;
 static TaskHandle_t s_vad_task = NULL;
+#if !CONFIG_TRANSPORT_MQTT_OFFLOAD
 static TaskHandle_t s_tcp_sender_task = NULL;
+#endif
 #if BOARD_TYPE_XVF3800
 static TaskHandle_t s_dsp_control_task = NULL;
 #endif
@@ -219,6 +227,13 @@ void app_main(void)
     }
 #endif
 
+#if CONFIG_TRANSPORT_MQTT_OFFLOAD
+    // Plug-and-play path: offload_app owns Wi-Fi (NVS creds -> default site SSID ->
+    // captive portal), discovers the sink via mDNS, negotiates, and starts the MQTT
+    // segment sender once an assignment arrives. No compiled server IP, no TCP client.
+    ESP_LOGI(TAG, "Starting plug-and-play offload app...");
+    offload_app_start(&s_app_ctx);
+#else
     // Initialize WiFi
     ESP_LOGI(TAG, "Initializing WiFi...");
     wifi_manager_config_t wifi_config = {
@@ -258,6 +273,7 @@ void app_main(void)
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Failed to start WiFi: %s", esp_err_to_name(ret));
     }
+#endif
 
     s_audio_state = AUDIO_STATE_RUNNING;
 
@@ -286,7 +302,9 @@ void app_main(void)
         TASK_CORE_AUDIO
     );
 
-    // TCP Sender Task (Core 0 - Network)
+#if !CONFIG_TRANSPORT_MQTT_OFFLOAD
+    // TCP Sender Task (Core 0 - Network). In offload mode the MQTT sender (started by
+    // offload_app once an assignment arrives) drains the speech queue instead.
     xTaskCreatePinnedToCore(
         tcp_sender_task,
         "tcp_sender",
@@ -296,6 +314,7 @@ void app_main(void)
         &s_tcp_sender_task,
         TASK_CORE_NETWORK
     );
+#endif
 
 #if BOARD_TYPE_XVF3800
     // DSP Control Task (Core 0 - Network)

--- a/data_ingestion_layer/firmware/main/net/discovery.c
+++ b/data_ingestion_layer/firmware/main/net/discovery.c
@@ -1,34 +1,91 @@
-// discovery.c — mDNS sink discovery with NVS/Kconfig fallback (skeleton).
-// SDK: components/mdns (add "mdns" to REQUIRES). See design doc §3.
+// discovery.c — mDNS sink discovery with NVS/Kconfig fallback.
+// SDK: managed component espressif/mdns (declared in main/idf_component.yml).
+// Resolution order: mDNS (_iotsensing-mqtt._tcp, advertised by deploy/mdns on the server,
+// PR #86) -> last-good broker from NVS -> compiled CONFIG_SERVER_HOST. The server IP is
+// never baked into a deployment: move the node to a new site and it finds the new sink.
 #include "net/discovery.h"
 #include <string.h>
 #include <stdio.h>
 #include "esp_log.h"
-// #include "mdns.h"
+#include "mdns.h"
 
 static const char *TAG = "discovery";
+static bool s_mdns_ready;
+
+static bool query_mdns(int timeout_ms, discovery_result_t *out) {
+    if (!s_mdns_ready) {
+        // mdns_init() is idempotent-ish but cheap to guard; hostname is set by the app.
+        if (mdns_init() != ESP_OK) {
+            ESP_LOGW(TAG, "mdns_init failed");
+            return false;
+        }
+        s_mdns_ready = true;
+    }
+
+    mdns_result_t *results = NULL;
+    esp_err_t err = mdns_query_ptr(DISCOVERY_SERVICE, DISCOVERY_PROTO, timeout_ms,
+                                   /*max_results=*/10, &results);
+    if (err != ESP_OK || results == NULL) {
+        return false;
+    }
+
+    bool found = false;
+    for (mdns_result_t *r = results; r && !found; r = r->next) {
+        // Prefer a result that carries an IPv4 address; fall back to the instance hostname.
+        for (mdns_ip_addr_t *a = r->addr; a; a = a->next) {
+            if (a->addr.type == ESP_IPADDR_TYPE_V4) {
+                esp_ip4addr_ntoa(&a->addr.u_addr.ip4, out->host, sizeof(out->host));
+                found = true;
+                break;
+            }
+        }
+        if (!found && r->hostname && r->hostname[0]) {
+            snprintf(out->host, sizeof(out->host), "%s.local", r->hostname);
+            found = true;
+        }
+        if (found) {
+            out->port = r->port > 0 ? r->port : 1883;
+            out->tls = false;
+            for (size_t i = 0; i < r->txt_count; i++) {
+                if (strcmp(r->txt[i].key, "tls") == 0 && r->txt[i].value &&
+                    strcmp(r->txt[i].value, "1") == 0) {
+                    out->tls = true;
+                }
+            }
+            out->from_mdns = true;
+        }
+    }
+    mdns_query_results_free(results);
+    return found;
+}
 
 bool discovery_find_sink(int timeout_ms, const char *fallback_host, int fallback_port,
                          discovery_result_t *out) {
     memset(out, 0, sizeof(*out));
-    // TODO(mdns): mdns_init() once at boot; then:
-    //   mdns_result_t *r = NULL;
-    //   mdns_query_ptr(DISCOVERY_SERVICE, DISCOVERY_PROTO, timeout_ms, 10, &r);
-    //   pick first responder; out->host = ip, out->port = r->port,
-    //   out->tls = TXT "tls"=="1"; out->from_mdns = true; mdns_query_results_free(r);
-    // Below is the fallback path used when mDNS yields nothing:
+
+    if (query_mdns(timeout_ms, out)) {
+        ESP_LOGI(TAG, "mDNS sink %s:%d tls=%d", out->host, out->port, out->tls);
+        return true;
+    }
+
+    // Fallback 1: last-good broker remembered from a previous successful session (NVS).
     if (fallback_host && fallback_host[0]) {
         strncpy(out->host, fallback_host, sizeof(out->host) - 1);
         out->port = fallback_port > 0 ? fallback_port : 1883;
         out->from_mdns = false;
-        ESP_LOGW(TAG, "mDNS empty; using stored/compiled broker %s:%d", out->host, out->port);
+        ESP_LOGW(TAG, "mDNS empty; using stored broker %s:%d", out->host, out->port);
         return true;
     }
+
+    // Fallback 2: compile-time default (dev convenience only; deployments use mDNS).
 #ifdef CONFIG_SERVER_HOST
-    strncpy(out->host, CONFIG_SERVER_HOST, sizeof(out->host) - 1);
-    out->port = 1883;
-    return true;
-#else
-    return false;
+    if (CONFIG_SERVER_HOST[0]) {
+        strncpy(out->host, CONFIG_SERVER_HOST, sizeof(out->host) - 1);
+        out->port = 1883;
+        out->from_mdns = false;
+        ESP_LOGW(TAG, "mDNS empty; using compiled broker %s:%d", out->host, out->port);
+        return true;
+    }
 #endif
+    return false;
 }

--- a/data_ingestion_layer/firmware/main/net/mqtt_client.c
+++ b/data_ingestion_layer/firmware/main/net/mqtt_client.c
@@ -1,51 +1,116 @@
-// mqtt_client.c — esp-mqtt wrapper (skeleton). SDK: components/mqtt (add "mqtt" to REQUIRES).
+// mqtt_client.c — thin esp-mqtt wrapper (auth, LWT, auto-reconnect, pub/sub).
+// SDK: components/mqtt ("mqtt" in REQUIRES). The broker requires credentials (PR #81);
+// per-node accounts are ACL-restricted to their own topics (PR #88).
 #include "net/mqtt_client.h"
 #include <string.h>
 #include <stdio.h>
 #include "esp_log.h"
-// #include "mqtt_client.h"  // esp-mqtt (note: same filename; include via <mqtt_client.h>)
+#include "mqtt_client.h"  // esp-mqtt (same basename; resolved via component include path)
 
 static const char *TAG = "mqtt";
-// static esp_mqtt_client_handle_t s_client;
-static bool s_connected;
+static esp_mqtt_client_handle_t s_client;
+static volatile bool s_connected;
 static mqtt_msg_cb_t s_cb;
 static void *s_user;
 
-// TODO(esp-mqtt): event handler.
-//  MQTT_EVENT_CONNECTED  -> s_connected = true
-//  MQTT_EVENT_DISCONNECTED -> s_connected = false  (esp-mqtt auto-reconnects)
-//  MQTT_EVENT_DATA -> if (s_cb) s_cb(event->topic, event->data, event->data_len, s_user);
+// nodes/{id}/config messages are small (<1 KB) and arrive in a single MQTT_EVENT_DATA.
+// Fragmented events (data_len < total_data_len) are logged and dropped rather than
+// half-parsed; nothing in the offload protocol legitimately exceeds the in-buffer size.
+static void event_handler(void *arg, esp_event_base_t base, int32_t event_id, void *event_data) {
+    esp_mqtt_event_handle_t event = event_data;
+    switch ((esp_mqtt_event_id_t)event_id) {
+    case MQTT_EVENT_CONNECTED:
+        s_connected = true;
+        ESP_LOGI(TAG, "connected");
+        break;
+    case MQTT_EVENT_DISCONNECTED:
+        s_connected = false;  // esp-mqtt keeps retrying on its own
+        ESP_LOGW(TAG, "disconnected");
+        break;
+    case MQTT_EVENT_DATA:
+        if (event->current_data_offset == 0 && event->data_len == event->total_data_len) {
+            if (s_cb) {
+                // topic is not NUL-terminated in the event; copy to a bounded buffer.
+                char topic[80];
+                int tl = event->topic_len < (int)sizeof(topic) - 1
+                             ? event->topic_len : (int)sizeof(topic) - 1;
+                memcpy(topic, event->topic, tl);
+                topic[tl] = '\0';
+                s_cb(topic, event->data, event->data_len, s_user);
+            }
+        } else {
+            ESP_LOGW(TAG, "fragmented message dropped (%d/%d bytes)",
+                     event->data_len, event->total_data_len);
+        }
+        break;
+    case MQTT_EVENT_ERROR:
+        if (event->error_handle &&
+            event->error_handle->error_type == MQTT_ERROR_TYPE_CONNECTION_REFUSED) {
+            ESP_LOGE(TAG, "broker refused connection (bad credentials / ACL?)");
+        }
+        break;
+    default:
+        break;
+    }
+}
 
 bool mqtt_client_start(const mqtt_client_cfg_t *cfg) {
-    s_cb = cfg->on_message; s_user = cfg->user;
+    s_cb = cfg->on_message;
+    s_user = cfg->user;
+
     char uri[96];
     snprintf(uri, sizeof(uri), "%s://%s:%d", cfg->tls ? "mqtts" : "mqtt", cfg->host, cfg->port);
     ESP_LOGI(TAG, "connecting %s as %s", uri, cfg->client_id);
-    // TODO: esp_mqtt_client_config_t mc = {
-    //   .broker.address.uri = uri,
-    //   .credentials = { .username = cfg->username, .client_id = cfg->client_id,
-    //                    .authentication.password = cfg->password },
-    //   .broker.verification.certificate = cfg->tls ? CA_PEM : NULL };
-    //   s_client = esp_mqtt_client_init(&mc);
-    //   esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, handler, NULL);
-    //   esp_mqtt_client_start(s_client);
-    return true;
+
+    esp_mqtt_client_config_t mc = {
+        .broker.address.uri = uri,
+        .credentials = {
+            .username = cfg->username[0] ? cfg->username : NULL,
+            .client_id = cfg->client_id,
+            .authentication.password = cfg->password[0] ? cfg->password : NULL,
+        },
+        .session = {
+            .keepalive = 30,
+            .last_will = {
+                .topic = cfg->lwt_topic[0] ? cfg->lwt_topic : NULL,
+                .msg = cfg->lwt_payload,
+                .msg_len = (int)strlen(cfg->lwt_payload),
+                .qos = 1,
+                .retain = true,
+            },
+        },
+        .network.reconnect_timeout_ms = 5000,
+        .buffer.size = 8192,          // inbound: config/assignment JSONs are small
+        // Outbound must hold one full base64 segment (8 s => ~342 KB). With
+        // CONFIG_SPIRAM_USE_MALLOC the allocation lands in PSRAM, not internal RAM.
+        .buffer.out_size = 384 * 1024,
+    };
+    // TODO(TLS): when the broker gains TLS, pin the CA:
+    //   mc.broker.verification.certificate = ca_pem;
+
+    s_client = esp_mqtt_client_init(&mc);
+    if (!s_client) return false;
+    esp_mqtt_client_register_event(s_client, ESP_EVENT_ANY_ID, event_handler, NULL);
+    return esp_mqtt_client_start(s_client) == ESP_OK;
 }
 
 bool mqtt_client_is_connected(void) { return s_connected; }
 
 bool mqtt_client_publish(const char *topic, const char *payload, int len, int qos, bool retain) {
-    // TODO: return esp_mqtt_client_publish(s_client, topic, payload, len, qos, retain) >= 0;
-    (void)topic; (void)payload; (void)len; (void)qos; (void)retain;
-    return s_connected;
+    if (!s_client) return false;
+    return esp_mqtt_client_publish(s_client, topic, payload, len, qos, retain) >= 0;
 }
 
 bool mqtt_client_subscribe(const char *topic, int qos) {
-    // TODO: return esp_mqtt_client_subscribe(s_client, topic, qos) >= 0;
-    (void)topic; (void)qos; return s_connected;
+    if (!s_client) return false;
+    return esp_mqtt_client_subscribe(s_client, topic, qos) >= 0;
 }
 
 void mqtt_client_stop(void) {
-    // TODO: esp_mqtt_client_stop(s_client); esp_mqtt_client_destroy(s_client);
+    if (s_client) {
+        esp_mqtt_client_stop(s_client);
+        esp_mqtt_client_destroy(s_client);
+        s_client = NULL;
+    }
     s_connected = false;
 }

--- a/data_ingestion_layer/firmware/main/net/mqtt_client.h
+++ b/data_ingestion_layer/firmware/main/net/mqtt_client.h
@@ -20,6 +20,10 @@ typedef struct {
     char client_id[40];    // node_id
     char username[33];
     char password[65];
+    // Last-will: published (retained) by the broker if the node dies uncleanly, so the
+    // dashboard's online/stale view never shows a dead node as alive. Empty topic => no LWT.
+    char lwt_topic[64];
+    char lwt_payload[64];
     mqtt_msg_cb_t on_message;
     void *user;
 } mqtt_client_cfg_t;

--- a/data_ingestion_layer/firmware/main/provisioning/provisioning.c
+++ b/data_ingestion_layer/firmware/main/provisioning/provisioning.c
@@ -1,16 +1,32 @@
-// provisioning.c — SoftAP/BLE Wi-Fi provisioning + NVS persistence (skeleton).
-// SDK: wifi_provisioning (scheme_softap or scheme_ble), nvs_flash. See design doc §2/§8.
+// provisioning.c — SoftAP captive-portal Wi-Fi provisioning + NVS persistence.
+//
+// UX (no app install, any phone): the unprovisioned node broadcasts the open AP
+// "IHearYou-Setup-XXXX". Joining it pops the OS captive-portal sheet (a micro-DNS server
+// answers every A query with 192.168.4.1), which shows a single form: Wi-Fi SSID +
+// password (+ optional room name). Submit -> creds persist to NVS -> reboot -> the node
+// joins the site network, mDNS-discovers the sink, and streams. MQTT credentials are NOT
+// collected here: the node bootstraps with the low-privilege enrollment account and the
+// server pushes per-node credentials after dashboard approval (see EDGE_TRUST_MODEL.md).
+//
+// SDK: esp_wifi (AP mode), esp_http_server, lwip raw UDP for DNS, nvs_flash.
 #include "provisioning/provisioning.h"
 #include <string.h>
 #include <stdio.h>
 #include "esp_log.h"
+#include "esp_wifi.h"
+#include "esp_netif.h"
+#include "esp_mac.h"
+#include "esp_http_server.h"
 #include "nvs.h"
-// #include "wifi_provisioning/manager.h"
-// #include "wifi_provisioning/scheme_softap.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/event_groups.h"
+#include "lwip/sockets.h"
 
 static const char *TAG = "prov";
 static const char *NS = "ihy_prov";
 
+// ---------------------------------------------------------------------------- NVS
 bool provisioning_load(prov_config_t *out) {
     memset(out, 0, sizeof(*out));
     nvs_handle_t h;
@@ -48,16 +64,179 @@ void provisioning_erase(void) {
     if (nvs_open(NS, NVS_READWRITE, &h) == ESP_OK) { nvs_erase_all(h); nvs_commit(h); nvs_close(h); }
 }
 
-bool provisioning_run_portal(prov_config_t *out, int timeout_s) {
-    ESP_LOGI(TAG, "SoftAP portal IHearYou-Setup-XXXX (timeout=%ds)", timeout_s);
-    // TODO(wifi_provisioning): wifi_prov_mgr_init(scheme_softap); start with a service name
-    //   derived from MAC; register a custom endpoint to also collect mqtt_user/mqtt_pass/uid/env;
-    //   on WIFI_PROV_CRED_RECV fill *out; on success persist and return true.
-    //   A captive-portal page (or the ESP BLE/SoftAP provisioning apps) drives the UX.
-    (void)out; (void)timeout_s;
-    return false;  // stub
+// ---------------------------------------------------------------------------- micro-DNS
+// Captive-portal detection: answer EVERY DNS A query with the SoftAP gateway (192.168.4.1).
+// Phones probe a known URL on join; hijacked DNS + HTTP 302 pops the portal sheet.
+static void dns_hijack_task(void *arg) {
+    int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    struct sockaddr_in addr = {
+        .sin_family = AF_INET, .sin_port = htons(53), .sin_addr.s_addr = htonl(INADDR_ANY),
+    };
+    if (sock < 0 || bind(sock, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+        ESP_LOGE(TAG, "dns bind failed");
+        vTaskDelete(NULL);
+        return;
+    }
+    uint8_t buf[512];
+    for (;;) {
+        struct sockaddr_in src;
+        socklen_t slen = sizeof(src);
+        int len = recvfrom(sock, buf, sizeof(buf), 0, (struct sockaddr *)&src, &slen);
+        if (len < 12) continue;
+        // Minimal DNS response: copy the query, set QR|AA flags, ANCOUNT=1, append one
+        // A record pointing at 192.168.4.1 via a name pointer to the question (0xC00C).
+        buf[2] = 0x84; buf[3] = 0x00;          // QR=1, AA=1, RCODE=0
+        buf[6] = 0x00; buf[7] = 0x01;          // ANCOUNT = 1
+        buf[8] = buf[9] = buf[10] = buf[11] = 0;  // NSCOUNT/ARCOUNT = 0
+        static const uint8_t answer[] = {
+            0xC0, 0x0C,             // name: pointer to offset 12 (the question)
+            0x00, 0x01, 0x00, 0x01, // TYPE A, CLASS IN
+            0x00, 0x00, 0x00, 0x3C, // TTL 60s
+            0x00, 0x04,             // RDLENGTH 4
+            192, 168, 4, 1,         // RDATA: the SoftAP gateway
+        };
+        if (len + (int)sizeof(answer) <= (int)sizeof(buf)) {
+            memcpy(buf + len, answer, sizeof(answer));
+            sendto(sock, buf, len + sizeof(answer), 0, (struct sockaddr *)&src, slen);
+        }
+    }
 }
 
+// ---------------------------------------------------------------------------- portal HTTP
+static prov_config_t *s_pending;
+static EventGroupHandle_t s_events;
+#define PROV_DONE_BIT BIT0
+
+static const char PORTAL_HTML[] =
+    "<!doctype html><html><head><meta name=viewport content='width=device-width,initial-scale=1'>"
+    "<title>IHearYou Setup</title><style>body{font-family:sans-serif;max-width:22rem;margin:2rem auto;padding:0 1rem}"
+    "input,button{width:100%;padding:.6rem;margin:.3rem 0;box-sizing:border-box}button{background:#2563eb;color:#fff;border:0;border-radius:4px}</style>"
+    "</head><body><h2>IHearYou node setup</h2>"
+    "<p>Connect this sensor to your Wi-Fi. It will find the IHearYou server on the network automatically.</p>"
+    "<form method=POST action=/save>"
+    "<input name=ssid placeholder='Wi-Fi network name' required maxlength=32>"
+    "<input name=pass type=password placeholder='Wi-Fi password' maxlength=64>"
+    "<input name=env placeholder='Room (e.g. livingroom)' maxlength=32>"
+    "<button type=submit>Save &amp; connect</button></form></body></html>";
+
+static const char DONE_HTML[] =
+    "<!doctype html><html><body style='font-family:sans-serif;text-align:center;margin-top:3rem'>"
+    "<h2>&#10003; Saved</h2><p>The node reboots and joins your network now.<br>"
+    "Approve it in the IHearYou dashboard (Edge Nodes &rarr; Pending).</p></body></html>";
+
+// Tiny x-www-form-urlencoded extractor (values are SSIDs/passwords, no '+ '&' edge magic
+// beyond %XX and '+').
+static void form_get(const char *body, const char *key, char *out, size_t out_len) {
+    out[0] = '\0';
+    char pat[24];
+    snprintf(pat, sizeof(pat), "%s=", key);
+    const char *p = strstr(body, pat);
+    if (!p) return;
+    p += strlen(pat);
+    size_t i = 0;
+    while (*p && *p != '&' && i < out_len - 1) {
+        if (*p == '+') { out[i++] = ' '; p++; }
+        else if (*p == '%' && p[1] && p[2]) {
+            char hex[3] = { p[1], p[2], 0 };
+            out[i++] = (char)strtol(hex, NULL, 16);
+            p += 3;
+        } else out[i++] = *p++;
+    }
+    out[i] = '\0';
+}
+
+static esp_err_t root_get(httpd_req_t *req) {
+    httpd_resp_set_type(req, "text/html");
+    return httpd_resp_send(req, PORTAL_HTML, HTTPD_RESP_USE_STRLEN);
+}
+
+// Any unknown URL (the phone's connectivity probe) redirects to the portal -> OS shows it.
+static esp_err_t redirect_handler(httpd_req_t *req, httpd_err_code_t err) {
+    httpd_resp_set_status(req, "302 Found");
+    httpd_resp_set_hdr(req, "Location", "http://192.168.4.1/");
+    return httpd_resp_send(req, NULL, 0);
+}
+
+static esp_err_t save_post(httpd_req_t *req) {
+    char body[512] = {0};
+    int len = httpd_req_recv(req, body, sizeof(body) - 1);
+    if (len <= 0) return httpd_resp_send_500(req);
+    form_get(body, "ssid", s_pending->wifi_ssid, sizeof(s_pending->wifi_ssid));
+    form_get(body, "pass", s_pending->wifi_pass, sizeof(s_pending->wifi_pass));
+    form_get(body, "env", s_pending->environment, sizeof(s_pending->environment));
+    if (!s_pending->environment[0]) strcpy(s_pending->environment, "unassigned");
+    if (!s_pending->wifi_ssid[0]) return httpd_resp_send_500(req);
+    httpd_resp_set_type(req, "text/html");
+    httpd_resp_send(req, DONE_HTML, HTTPD_RESP_USE_STRLEN);
+    vTaskDelay(pdMS_TO_TICKS(200));  // let the response flush before signaling
+    xEventGroupSetBits(s_events, PROV_DONE_BIT);
+    return ESP_OK;
+}
+
+// ---------------------------------------------------------------------------- portal
+bool provisioning_run_portal(prov_config_t *out, int timeout_s) {
+    s_pending = out;
+    s_events = xEventGroupCreate();
+
+    // SoftAP "IHearYou-Setup-XXXX" (XXXX = last 2 MAC bytes), open, channel 1.
+    uint8_t mac[6];
+    esp_read_mac(mac, ESP_MAC_WIFI_SOFTAP);
+    wifi_config_t ap = {0};
+    snprintf((char *)ap.ap.ssid, sizeof(ap.ap.ssid), "IHearYou-Setup-%02X%02X", mac[4], mac[5]);
+    ap.ap.ssid_len = strlen((char *)ap.ap.ssid);
+    ap.ap.authmode = WIFI_AUTH_OPEN;
+    ap.ap.max_connection = 2;
+
+    esp_netif_create_default_wifi_ap();
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_AP));
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &ap));
+    ESP_ERROR_CHECK(esp_wifi_start());
+    ESP_LOGI(TAG, "portal AP up: %s", ap.ap.ssid);
+
+    TaskHandle_t dns_task;
+    xTaskCreate(dns_hijack_task, "prov_dns", 3072, NULL, 5, &dns_task);
+
+    httpd_handle_t server = NULL;
+    httpd_config_t hc = HTTPD_DEFAULT_CONFIG();
+    hc.max_uri_handlers = 4;
+    ESP_ERROR_CHECK(httpd_start(&server, &hc));
+    httpd_uri_t u_root = { .uri = "/", .method = HTTP_GET, .handler = root_get };
+    httpd_uri_t u_save = { .uri = "/save", .method = HTTP_POST, .handler = save_post };
+    httpd_register_uri_handler(server, &u_root);
+    httpd_register_uri_handler(server, &u_save);
+    httpd_register_err_handler(server, HTTPD_404_NOT_FOUND, redirect_handler);
+
+    TickType_t wait = timeout_s > 0 ? pdMS_TO_TICKS((uint32_t)timeout_s * 1000) : portMAX_DELAY;
+    EventBits_t bits = xEventGroupWaitBits(s_events, PROV_DONE_BIT, pdTRUE, pdTRUE, wait);
+    bool ok = (bits & PROV_DONE_BIT) != 0;
+
+    httpd_stop(server);
+    vTaskDelete(dns_task);
+    esp_wifi_stop();
+    vEventGroupDelete(s_events);
+
+    if (ok) {
+        provisioning_save(out);
+        ESP_LOGI(TAG, "provisioned for SSID '%s' (env '%s'); restarting",
+                 out->wifi_ssid, out->environment);
+        esp_restart();  // clean boot into STA mode with the fresh creds
+    }
+    return ok;
+}
+
+// ---------------------------------------------------------------------------- factory reset
+// Poll BOOT (GPIO0): held >=5 s -> wipe provisioning + reboot into the portal.
+#include "driver/gpio.h"
 void provisioning_check_factory_reset(void) {
-    // TODO: poll GPIO0; if held >=5s -> provisioning_erase() + esp_restart().
+    static int held_ms;
+    if (gpio_get_level(GPIO_NUM_0) == 0) {
+        held_ms += 100;
+        if (held_ms >= 5000) {
+            ESP_LOGW(TAG, "factory reset: erasing provisioning");
+            provisioning_erase();
+            esp_restart();
+        }
+    } else {
+        held_ms = 0;
+    }
 }

--- a/data_ingestion_layer/firmware/main/transport/mqtt_sender.c
+++ b/data_ingestion_layer/firmware/main/transport/mqtt_sender.c
@@ -1,0 +1,126 @@
+// mqtt_sender.c — speech-segment publisher for the plug-and-play offload path.
+#include "transport/mqtt_sender.h"
+#include "net/mqtt_client.h"
+#include "audio/audio_buffer.h"
+#include "audio/audio_quality.h"
+#include "features/edge_features.h"
+#include "config/audio_config.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "esp_timer.h"
+#include "mbedtls/base64.h"
+#include <string.h>
+#include <sys/time.h>
+
+static const char *TAG = "mqtt_sender";
+
+// One utterance segment per message. 8 s @ 16 kHz mono s16 = 256 KB PCM (~342 KB base64);
+// staged in PSRAM, well under the broker's 4 MB message_size_limit (PR #87).
+#define SEG_MAX_BYTES (16000 * 2 * 8)
+
+static mqtt_sender_stats_t s_stats;
+
+void mqtt_sender_get_stats(mqtt_sender_stats_t *out) { *out = s_stats; }
+
+static double now_unix(void) {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (double)tv.tv_sec + (double)tv.tv_usec / 1e6;
+}
+
+static void fill_meta(app_ctx_t *ctx, np_payload_meta_t *m) {
+    memset(m, 0, sizeof(*m));
+    m->user_id = ctx->prov.user_id;                 // <=0 => server-side recognition
+    m->board_id = ctx->node_id;
+    m->environment_name = ctx->prov.environment[0] ? ctx->prov.environment : "unassigned";
+    m->system_mode = "live";                        // server overrides with the ENROLLED mode
+    m->timestamp = now_unix();
+    m->sample_rate = 16000;
+    m->doa_azimuth = ctx->latest_doa;               // INT16_MIN when no XVF3800
+}
+
+static void publish_segment(app_ctx_t *ctx, const uint8_t *pcm, size_t pcm_len,
+                            unsigned char *b64, size_t b64_cap) {
+    np_payload_meta_t meta;
+    fill_meta(ctx, &meta);
+
+    char *json = NULL;
+    if (ctx->assignment.mode == NP_MODE_FEATURES) {
+        // Feature mode: only the ASSIGNED allow-listed metrics leave the node -- no audio
+        // at all. (The server's gap-filler skips the matching extractors; PR #82/#87.)
+        uint32_t mask = 0;
+        for (int i = 0; ctx->assignment.features[i]; i++) {
+            if (!strcmp(ctx->assignment.features[i], NP_FEAT_SNR)) mask |= EF_SNR;
+            else if (!strcmp(ctx->assignment.features[i], NP_FEAT_SPECTRAL_FLATNESS)) mask |= EF_SPECTRAL_FLATNESS;
+            else if (!strcmp(ctx->assignment.features[i], NP_FEAT_TEMPORAL_MODULATION)) mask |= EF_TEMPORAL_MODULATION;
+            else if (!strcmp(ctx->assignment.features[i], NP_FEAT_SPECTRAL_MODULATION)) mask |= EF_SPECTRAL_MODULATION;
+        }
+        edge_features_t f = {0};
+        edge_features_compute((const int16_t *)pcm, (int)(pcm_len / 2),
+                              /*noise_floor=*/0.0f, mask, &f);
+        size_t k = 0;
+        if (f.has_snr)               { meta.feature_names[k] = NP_FEAT_SNR;                 meta.feature_values[k++] = f.snr; }
+        if (f.has_spectral_flatness) { meta.feature_names[k] = NP_FEAT_SPECTRAL_FLATNESS;   meta.feature_values[k++] = f.spectral_flatness; }
+        if (f.has_temporal_modulation) { meta.feature_names[k] = NP_FEAT_TEMPORAL_MODULATION; meta.feature_values[k++] = f.temporal_modulation; }
+        if (f.has_spectral_modulation) { meta.feature_names[k] = NP_FEAT_SPECTRAL_MODULATION; meta.feature_values[k++] = f.spectral_modulation; }
+        meta.feature_count = k;
+        json = np_build_audio_payload_json(NULL, &meta);
+    } else {
+        // Segments mode (default): base64 the VAD-gated utterance.
+        size_t b64_len = 0;
+        if (mbedtls_base64_encode(b64, b64_cap, &b64_len, pcm, pcm_len) != 0) {
+            ESP_LOGE(TAG, "base64 overflow (%u bytes pcm)", (unsigned)pcm_len);
+            s_stats.segments_dropped++;
+            return;
+        }
+        b64[b64_len] = '\0';
+        json = np_build_audio_payload_json((const char *)b64, &meta);
+    }
+    if (!json) { s_stats.segments_dropped++; return; }
+
+    char topic[96];
+    np_topic_voice(&meta, topic, sizeof(topic));
+    // QoS1, no retain: an utterance is delivered at-least-once; the server-side handlers
+    // are idempotent per (timestamp, board_id).
+    if (mqtt_client_publish(topic, json, strlen(json), 1, false)) {
+        s_stats.segments_published++;
+    } else {
+        s_stats.publish_failures++;
+    }
+    free(json);
+}
+
+static void sender_task(void *arg) {
+    app_ctx_t *ctx = (app_ctx_t *)arg;
+
+    uint8_t *pcm = heap_caps_malloc(SEG_MAX_BYTES, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    size_t b64_cap = (SEG_MAX_BYTES / 3 + 2) * 4 + 4;
+    unsigned char *b64 = heap_caps_malloc(b64_cap, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!pcm || !b64) {
+        ESP_LOGE(TAG, "PSRAM alloc failed; sender disabled");
+        vTaskDelete(NULL);
+        return;
+    }
+
+    audio_quality_metrics_t metrics;
+    size_t got = 0;
+    for (;;) {
+        if (audio_buffer_read_speech(pcm, SEG_MAX_BYTES, &got, &metrics,
+                                     pdMS_TO_TICKS(1000)) != ESP_OK || got == 0) {
+            continue;  // no speech in the last second
+        }
+        if (!ctx->assignment.valid || !mqtt_client_is_connected()) {
+            // Not negotiated / offline: drop (the ring buffer keeps absorbing upstream;
+            // privacy over completeness -- we never spool voice to flash).
+            s_stats.segments_dropped++;
+            continue;
+        }
+        publish_segment(ctx, pcm, got, b64, b64_cap);
+    }
+}
+
+void mqtt_sender_start(app_ctx_t *ctx) {
+    xTaskCreatePinnedToCore(sender_task, "mqtt_sender", 8192, ctx, 8, NULL, 1);
+}

--- a/data_ingestion_layer/firmware/main/transport/mqtt_sender.h
+++ b/data_ingestion_layer/firmware/main/transport/mqtt_sender.h
@@ -1,0 +1,29 @@
+// mqtt_sender.h — VAD-gated speech segments -> AudioPayload JSON -> voice/{user}/{node}/{env}.
+//
+// The offload counterpart of tcp_client: drains the same speech queue the legacy TCP
+// sender reads (audio_buffer_read_speech) and publishes each utterance segment as one
+// MQTT AudioPayload message, honoring the live assignment (ctx->assignment.mode).
+// NP_MODE_FEATURES is a later phase: this sender publishes SEGMENTS; when the assignment
+// says FEATURES it computes edge_features over the segment and publishes metrics only.
+#pragma once
+#include "app/offload_app.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Start the sender task (reads ctx->assignment / mqtt connection state live).
+void mqtt_sender_start(app_ctx_t *ctx);
+
+// Counters for telemetry/status.
+typedef struct {
+    uint32_t segments_published;
+    uint32_t segments_dropped;      // not connected / mode==RAW-unsupported / overflow
+    uint32_t publish_failures;
+} mqtt_sender_stats_t;
+
+void mqtt_sender_get_stats(mqtt_sender_stats_t *out);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Completes the P1 skeleton (PR #85 design) into full implementations. Compile/flash pending ESP-IDF + hardware.

**The zero-config chain (clinic scenario):**
1. Factory-fresh board first tries `CONFIG_DEFAULT_SITE_SSID` ("IHearYou-Net" — broadcast it from the site's central node and boards need **zero per-device setup**).
2. No default network → SoftAP **"IHearYou-Setup-XXXX"** captive portal (micro-DNS hijack + esp_http_server; any phone browser, no app): one form — Wi-Fi + room name. No MQTT credentials asked, ever.
3. Joins network → **mDNS-discovers** `_iotsensing-mqtt._tcp` (server side merged in #86) → connects with the low-privilege **bootstrap account** → publishes retained capabilities → appears in dashboard **Edge Nodes → Pending**.
4. Operator approves → registry pushes assignment (and later per-node creds on `nodes/{id}/provision`) → VAD-gated segments flow as AudioPayload JSON to `voice/{user}/{node}/{env}`.

**New/completed:** provisioning portal (NVS + captive portal + BOOT-hold factory reset), real mDNS discovery (TXT tls, NVS last-good broker), full esp-mqtt wrapper (auth, retained LWT, PSRAM out-buffer), `transport/mqtt_sender` (segments + assigned-features modes, drains the same speech queue as legacy TCP), upgraded offload_app state machine (default-SSID fallback, broker persistence, retained status heartbeats, waits-connected when unapproved), Kconfig transport choice (legacy TCP path preserved).

**Server-side deltas still needed (small, listed in order):**
- mosquitto: `node-bootstrap` account + ACL (pub `nodes/+/capabilities|status`, sub `nodes/+/config|provision`)
- node_registry: mark unapproved nodes `pending` instead of auto-assigning
- dashboard Edge Nodes: Pending section + Approve button → calls enroll + publishes assignment
- (P2) mint per-node creds at approval, push on `nodes/{id}/provision`; firmware handler is TODO-marked in `offload_app_on_mqtt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)