### PR TITLE
fix(extractors): missing-data convention, spectral_modulation band, true F1, single-tracker F0, relative silence gate

### DIFF
--- a/processing_layer/metrics_computation/voice_metrics/core/MetricsComputationService.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/MetricsComputationService.py
@@ -280,8 +280,9 @@ class MetricsComputationService:
             t13_value = get_t13_from_states(voiced_states)
             results["interaction_dynamics"] = get_interaction_dynamics_from_states(voiced_states)
         else:
-            voiced16_20 = 0.0
-            t13_value = 0.0
+            # Unmeasured, not zero -- safe_float(None) omits these from the record.
+            voiced16_20 = None
+            t13_value = None
             results["interaction_dynamics"] = None
 
         # Define which myprosody metrics should be returned
@@ -296,18 +297,26 @@ class MetricsComputationService:
             audio_np, sample_rate, myprosody_metrics_to_extract
         )
 
-        # Helper to safely get result and handle potential None/Errors
-        def safe_float(val, default=0.0):
+        # Missing-data convention: an unmeasurable metric is None and is OMITTED from the
+        # persisted record -- never stored as 0.0 (a fake measurement) and never as NaN
+        # (which Mongo $avg does NOT skip, so one NaN poisons every downstream average).
+        # Silence/noise-only segments previously wrote jitter=shimmer=hnr=f0=0.0, encoding
+        # silence density (itself correlated with psychomotor retardation) into the feature
+        # statistics -- a fabricated depression signal.
+        def safe_float(val):
             try:
                 if val is None:
-                    return default
+                    return None
                 if hasattr(val, "values"):  # Handle pandas Series from opensmile
-                    return float(val.values[0])
-                if isinstance(val, (list, np.ndarray)) and len(val) > 0:
-                    return float(val[0])
-                return float(val)
-            except:
-                return default
+                    val = val.values[0]
+                elif isinstance(val, (list, np.ndarray)):
+                    if len(val) == 0:
+                        return None
+                    val = val[0]
+                val = float(val)
+                return val if np.isfinite(val) else None
+            except (TypeError, ValueError, IndexError):
+                return None
 
         # ----------------------------
         # Flatten all metrics into a single dictionary
@@ -342,13 +351,22 @@ class MetricsComputationService:
             "f2_transition_speed": safe_float(results.get("f2_transition_speed")),
         })
 
-        # Add myprosody results
-        flat_metrics.update(myprosody_results)
+        # Add myprosody results (through the same missing-data convention)
+        for _name, _value in myprosody_results.items():
+            flat_metrics[_name] = safe_float(_value)
 
         # Edge-offload: node-provided features are authoritative for whatever the node
         # computed (and include any node-only feature not produced server-side).
         for _name, _value in provided_features.items():
             flat_metrics[_name] = safe_float(_value)
+
+        # Drop unmeasured metrics entirely: absent key = "not measured on this segment".
+        # Downstream day-aggregation (pandas dropna) then averages over measured values
+        # only, instead of blending in placeholder zeros/NaNs.
+        n_before = len(flat_metrics)
+        flat_metrics = {k: v for k, v in flat_metrics.items() if v is not None}
+        if len(flat_metrics) < n_before:
+            print(f"ℹ️ {n_before - len(flat_metrics)} unmeasured metrics omitted for this segment")
 
         # SAFETY GUARD: Use real-time unless simulation is forced
         if self.simulation_mode:

--- a/processing_layer/metrics_computation/voice_metrics/core/extractors/f0.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/extractors/f0.py
@@ -96,26 +96,29 @@ def get_f0_dynamic(features_LLD, audio_signal, sr, librosa_f0=None) -> dict:
     """
     f0_opensmile_hz, f0_librosa = _extract_f0_contour(features_LLD, audio_signal, sr, librosa_f0)
 
-    # Combine both sources for more robust estimates
-    all_f0 = []
-    if len(f0_opensmile_hz) > 0:
-        all_f0.extend(f0_opensmile_hz.tolist())
+    # Use a SINGLE tracker per utterance -- never pool. Pooling OpenSMILE- and pyin-derived
+    # Hz into one array injected the systematic between-tracker offset into every dispersion
+    # statistic (f0_std/range/cv/entropy: the core monotonicity markers) and made f0_avg a
+    # frame-count-weighted blend. Prefer the shared pyin contour (it also drives voicing);
+    # fall back to the OpenSMILE contour only when pyin found no voiced frames.
     if len(f0_librosa) > 0:
-        all_f0.extend(f0_librosa.tolist())
-
-    all_f0 = np.array(all_f0)
+        all_f0 = np.asarray(f0_librosa, dtype=float)
+    else:
+        all_f0 = np.asarray(f0_opensmile_hz, dtype=float)
 
     if len(all_f0) == 0:
+        # NaN = "not measurable" (no voiced frames); omitted by the service, not zeroed.
+        nan = float("nan")
         return {
-            "f0_avg": 0.0,
-            "f0_std": 0.0,
-            "f0_range": 0.0,
-            "f0_cv": 0.0,
-            "f0_iqr": 0.0,
-            "f0_entropy": 0.0,
+            "f0_avg": nan,
+            "f0_std": nan,
+            "f0_range": nan,
+            "f0_cv": nan,
+            "f0_iqr": nan,
+            "f0_entropy": nan,
         }
 
-    # Compute legacy metrics (averaged between sources for consistency)
+    # Legacy metrics, computed on the single selected contour
     f0_mean = float(np.mean(all_f0))
     f0_std = float(np.std(all_f0))
     f0_range = float(np.max(all_f0) - np.min(all_f0))

--- a/processing_layer/metrics_computation/voice_metrics/core/extractors/formants.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/extractors/formants.py
@@ -14,9 +14,10 @@ Clinical Relevance:
 - Lower formant frequencies: Potential indicator of fatigue
 - F2 transition speed is measured separately for articulatory dynamics
 
-Note: This module currently extracts F1 frequencies using the eGeMAPS
-F2frequency field (which corresponds to the second formant in OpenSMILE).
-The naming is preserved for backward compatibility with existing mappings.
+Note: the formant_f1_* keys now genuinely contain FIRST-formant statistics
+(eGeMAPSv02 F1frequency_sma3nz). Historically this module filtered
+F2frequency_sma3nz while labeling the outputs F1 — any number published from
+the old code under an "F1" label was actually F2.
 """
 
 import numpy as np
@@ -34,7 +35,9 @@ def _extract_formant_series(features_LLD) -> np.ndarray:
     Returns:
         numpy array of formant frequency values
     """
-    formant_series = features_LLD.filter(like="F2frequency_sma3nz", axis=1)
+    # F1 = F1frequency_sma3nz. (F2 lives in F2frequency_sma3nz and is consumed separately
+    # by f2_transition_speed; it must NOT be relabeled as F1.)
+    formant_series = features_LLD.filter(like="F1frequency_sma3nz", axis=1)
 
     if formant_series.empty:
         return np.array([])
@@ -65,12 +68,14 @@ def get_formant_dynamic(features_LLD) -> dict:
     formant_series = _extract_formant_series(features_LLD)
 
     if len(formant_series) == 0:
+        # NaN = "not measurable" (no voiced frames); omitted by the service, not zeroed.
+        nan = float("nan")
         return {
-            "formant_f1_frequencies_mean": 0.0,
-            "formant_f1_std": 0.0,
-            "formant_f1_cv": 0.0,
-            "formant_f1_iqr": 0.0,
-            "formant_f1_entropy": 0.0,
+            "formant_f1_frequencies_mean": nan,
+            "formant_f1_std": nan,
+            "formant_f1_cv": nan,
+            "formant_f1_iqr": nan,
+            "formant_f1_entropy": nan,
         }
 
     return {
@@ -92,4 +97,4 @@ def get_formant_f1_frequencies(features_LLD):
     LEGACY: Use get_formant_dynamic() for new implementations.
     """
     formant_series = _extract_formant_series(features_LLD)
-    return float(np.mean(formant_series)) if len(formant_series) > 0 else 0.0
+    return float(np.mean(formant_series)) if len(formant_series) > 0 else float("nan")

--- a/processing_layer/metrics_computation/voice_metrics/core/extractors/hnr.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/extractors/hnr.py
@@ -58,12 +58,15 @@ def get_hnr_dynamic(features_LLD) -> dict:
     hnr_series = _extract_hnr_series(features_LLD)
 
     if len(hnr_series) == 0:
+        # NaN = "not measurable" (no voiced frames): the service omits these instead of
+        # persisting fake zeros that would encode silence density into the HNR statistics.
+        nan = float("nan")
         return {
-            "hnr_mean": 0.0,
-            "hnr_std": 0.0,
-            "hnr_cv": 0.0,
-            "hnr_iqr": 0.0,
-            "hnr_entropy": 0.0,
+            "hnr_mean": nan,
+            "hnr_std": nan,
+            "hnr_cv": nan,
+            "hnr_iqr": nan,
+            "hnr_entropy": nan,
         }
 
     return {
@@ -85,4 +88,4 @@ def get_hnr_mean(features_LLD):
     LEGACY: Use get_hnr_dynamic() for new implementations.
     """
     hnr_series = _extract_hnr_series(features_LLD)
-    return float(np.mean(hnr_series)) if len(hnr_series) > 0 else 0.0
+    return float(np.mean(hnr_series)) if len(hnr_series) > 0 else float("nan")

--- a/processing_layer/metrics_computation/voice_metrics/core/extractors/jitter.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/extractors/jitter.py
@@ -5,5 +5,7 @@ def get_jitter(features_LLD):
     if "jitterLocal_sma3nz" in features_LLD.columns:
         # sma3nz features are non-zero only for voiced frames
         jitter_voiced = features_LLD[features_LLD["jitterLocal_sma3nz"] > 0]["jitterLocal_sma3nz"]
-        return jitter_voiced.mean() if not jitter_voiced.empty else 0.0
-    return 0.0
+        # NaN = "not measurable on this segment" (no voiced frames); the service
+        # OMITS NaN metrics instead of persisting a fake 0.0 measurement.
+        return jitter_voiced.mean() if not jitter_voiced.empty else float("nan")
+    return float("nan")

--- a/processing_layer/metrics_computation/voice_metrics/core/extractors/shimmer.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/extractors/shimmer.py
@@ -5,5 +5,6 @@ def get_shimmer(features_LLD):
     # eGeMAPSv02's shimmer column is shimmerLocaldB_sma3nz (0 on unvoiced frames).
     if "shimmerLocaldB_sma3nz" in features_LLD.columns:
         shimmer_voiced = features_LLD[features_LLD["shimmerLocaldB_sma3nz"] > 0]["shimmerLocaldB_sma3nz"]
-        return shimmer_voiced.mean() if not shimmer_voiced.empty else 0.0
-    return 0.0
+        # NaN = "not measurable on this segment" (no voiced frames); see jitter.py.
+        return shimmer_voiced.mean() if not shimmer_voiced.empty else float("nan")
+    return float("nan")

--- a/processing_layer/metrics_computation/voice_metrics/core/extractors/spectral_modulation.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/extractors/spectral_modulation.py
@@ -19,12 +19,18 @@ def get_spectral_modulation(audio_np, sample_rate, log_S=None):
     fft_result = np.fft.fft(log_S_centered, axis=0)
     power = np.abs(fft_result) ** 2
     
-    # Compute freqs once (same for all frames)
-    freqs = np.fft.fftfreq(log_S.shape[0], d=1)  # unit = bins
-    
-    # Find target bin once (same for all frames)
-    # Assumption: log-mel spacing → ~1 bin per 0.1 oct, so 2 cyc/oct ~ bin 20
-    target_bin = np.argmin(np.abs(freqs - 2))
+    # Compute freqs once (same for all frames). fftfreq with d=1 yields CYCLES PER MEL BIN
+    # (max 0.5), NOT cycles/octave.
+    freqs = np.fft.fftfreq(log_S.shape[0], d=1)  # unit = cycles/bin
+
+    # Target: ~2 cycles/octave. With log-mel spacing of ~0.1 octave per mel bin, that is
+    # ~0.2 cycles/bin. The previous code searched for "2" on the cycles/bin axis, which is
+    # beyond Nyquist (0.5) -- argmin snapped to the highest positive bin every time, so the
+    # feature measured mel-axis Nyquist ripple regardless of input.
+    OCTAVES_PER_MEL_BIN = 0.1
+    target_cycles_per_bin = 2.0 * OCTAVES_PER_MEL_BIN  # = 0.2
+    positive = freqs > 0
+    target_bin = np.argmin(np.abs(freqs - target_cycles_per_bin) + (~positive) * 1e6)
     
     # Extract modulation energy at target bin across all frames
     spec_mod_power = power[target_bin, :]

--- a/processing_layer/metrics_computation/voice_metrics/core/extractors/voicing_states.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/extractors/voicing_states.py
@@ -75,15 +75,21 @@ def classify_voicing_states(audio_np, sample_rate, frame_length=0.04, hop_length
     rms = rms[:n]
     voiced_flag = voiced_flag[:n]
 
-    # Silence gate: RELATIVE to the segment's own noise floor, not a fixed absolute RMS.
+    # Silence gate: RELATIVE to the segment's own dynamic range, not a fixed absolute RMS.
     # A hard constant (old RMS_THRESHOLD=0.01) made silence_ratio/pause_*/voiced_ratio/
     # speech_velocity gain-dependent: the same speech lands on opposite sides of the gate
     # for a quiet dataset recording vs a hot ReSpeaker capture, breaking comparability
-    # between published (DAIC-WOZ) and deployed numbers. Noise floor = 5th percentile of
-    # frame RMS; a frame counts as non-silent above 3x that floor. RMS_THRESHOLD survives
-    # only as an absolute lower bound for digital-silence segments.
-    noise_floor = float(np.percentile(rms, 5)) if len(rms) else 0.0
-    silence_gate = max(RMS_THRESHOLD * 0.01, 3.0 * noise_floor)
+    # between published (DAIC-WOZ) and deployed numbers. The gate sits 10% up the range
+    # between the noise floor (5th pct of frame RMS) and the loud level (95th pct):
+    # speech pauses fall below it, audible energy (speech OR broadband noise) above it,
+    # and it scales with recording gain. RMS_THRESHOLD survives only as a tiny absolute
+    # lower bound so digital silence never counts as sound.
+    if len(rms):
+        noise_floor = float(np.percentile(rms, 5))
+        loud_level = float(np.percentile(rms, 95))
+    else:
+        noise_floor = loud_level = 0.0
+    silence_gate = max(RMS_THRESHOLD * 0.01, noise_floor + 0.10 * (loud_level - noise_floor))
 
     # Priority: voiced (1) > unvoiced (2) > silence (3)
     state_sequence = np.where(

--- a/processing_layer/metrics_computation/voice_metrics/core/extractors/voicing_states.py
+++ b/processing_layer/metrics_computation/voice_metrics/core/extractors/voicing_states.py
@@ -75,11 +75,21 @@ def classify_voicing_states(audio_np, sample_rate, frame_length=0.04, hop_length
     rms = rms[:n]
     voiced_flag = voiced_flag[:n]
 
+    # Silence gate: RELATIVE to the segment's own noise floor, not a fixed absolute RMS.
+    # A hard constant (old RMS_THRESHOLD=0.01) made silence_ratio/pause_*/voiced_ratio/
+    # speech_velocity gain-dependent: the same speech lands on opposite sides of the gate
+    # for a quiet dataset recording vs a hot ReSpeaker capture, breaking comparability
+    # between published (DAIC-WOZ) and deployed numbers. Noise floor = 5th percentile of
+    # frame RMS; a frame counts as non-silent above 3x that floor. RMS_THRESHOLD survives
+    # only as an absolute lower bound for digital-silence segments.
+    noise_floor = float(np.percentile(rms, 5)) if len(rms) else 0.0
+    silence_gate = max(RMS_THRESHOLD * 0.01, 3.0 * noise_floor)
+
     # Priority: voiced (1) > unvoiced (2) > silence (3)
     state_sequence = np.where(
         voiced_flag,
         1,  # Voiced (periodic / harmonic)
-        np.where(rms > RMS_THRESHOLD, 2, 3),  # Unvoiced (energy, no pitch) or Silence
+        np.where(rms > silence_gate, 2, 3),  # Unvoiced (energy, no pitch) or Silence
     )
 
     return state_sequence.tolist()

--- a/processing_layer/metrics_computation/voice_metrics/tests/test_hnr.py
+++ b/processing_layer/metrics_computation/voice_metrics/tests/test_hnr.py
@@ -38,16 +38,14 @@ def test_all_negative_voice_is_not_treated_as_silence():
     assert d["hnr_mean"] == -2.0
 
 
-def test_all_unvoiced_returns_zero_dict():
+def test_all_unvoiced_returns_nan_dict():
+    # Unmeasurable (no voiced frames) must be NaN ("not measured"), NOT 0.0: a fake zero
+    # would be persisted as a real measurement and encode silence density into HNR stats.
+    import math
     lld = _lld([0.0, 0.0, 0.0])
     d = get_hnr_dynamic(lld)
-    assert d == {
-        "hnr_mean": 0.0,
-        "hnr_std": 0.0,
-        "hnr_cv": 0.0,
-        "hnr_iqr": 0.0,
-        "hnr_entropy": 0.0,
-    }
+    assert set(d) == {"hnr_mean", "hnr_std", "hnr_cv", "hnr_iqr", "hnr_entropy"}
+    assert all(math.isnan(v) for v in d.values())
 
 
 def test_positive_only_unchanged():

--- a/processing_layer/metrics_computation/voice_metrics/tests/test_shimmer.py
+++ b/processing_layer/metrics_computation/voice_metrics/tests/test_shimmer.py
@@ -19,5 +19,7 @@ def test_shimmer_reads_real_column_and_averages_voiced():
     assert get_shimmer(lld) == 2.0
 
 
-def test_shimmer_all_unvoiced_is_zero():
-    assert get_shimmer(_lld([0.0, 0.0])) == 0.0
+def test_shimmer_all_unvoiced_is_nan():
+    # Unmeasurable -> NaN ("not measured"), not a fake 0.0 measurement.
+    import math
+    assert math.isnan(get_shimmer(_lld([0.0, 0.0])))


### PR DESCRIPTION
Review round-3 extractor fixes. 42/42 tests pass on the VM.

- **C1** Silence/noise segments no longer fabricate zero-valued biomarkers: unmeasurable → NaN → **omitted** from the record (0.0 encoded silence density — itself psychomotor-correlated — into jitter/shimmer/HNR/F0/formants; NaN would poison Mongo $avg). Myprosody + t13/voiced16_20 routed through the same convention.
- **C2** `spectral_modulation` measured mel-axis Nyquist ripple on every utterance (searched 2 on a cycles/bin axis capped at 0.5) → now targets 2 cyc/oct = 0.2 cyc/bin. **All previous spectral_modulation values are meaningless.**
- **M1** F0 dispersion metrics on a single tracker (pyin; OpenSMILE fallback) — pooling inflated f0_std/range/cv/entropy via between-tracker offset.
- **M2** `formant_f1_*` now actually extracts **F1** (was F2frequency mislabeled as F1 — any published 'F1' numbers were F2).
- **M3** Silence gate relative to segment dynamic range (floor + 10%·(p95−floor)) — gain-independent; fixed threshold made DAIC-WOZ vs live hardware non-comparable.

⚠️ Together with the openSMILE column fix (PR #79): **all historical extraction results are invalid for publication; DAIC-WOZ must be re-ingested after merge.**

Deferred minors (disclose in paper or fix later): hnr_cv ill-defined for mean≤0, entropy small-sample bias, glottal rate over total duration, no voicing gating on SNR/flatness/PSD, drop-oldest MQTT queue without drop accounting, no mono-downmix guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)